### PR TITLE
- report failed ioctls in clonefile() as warning only

### DIFF
--- a/snapper/AppUtil.cc
+++ b/snapper/AppUtil.cc
@@ -79,7 +79,7 @@ namespace snapper
 	int r1 = ioctl(dest_fd, BTRFS_IOC_CLONE, src_fd);
 	if (r1 != 0)
 	{
-	    y2err("ioctl failed errno:" << errno << " (" << stringerror(errno) << ")");
+	    y2war("ioctl failed errno:" << errno << " (" << stringerror(errno) << ")");
 	}
 
 	return r1 == 0;


### PR DESCRIPTION
On thin-provisioned volumes, this will cause an error message for each file that is supposed to be created during 'undochange' command. I was thinking about possible general fix (i.e. get info about underlying filesystem, if it's != btrfs then...), but in the end this looks to me as an easiest solution for now.
I don't know how big is the issue when clonefile() possibly fails on btrfs...
