### PR TITLE
- remove unused copy constructor and assign operator

### DIFF
--- a/snapper/XAttributes.cc
+++ b/snapper/XAttributes.cc
@@ -98,23 +98,6 @@ namespace snapper
         }
     }
 
-    XAttributes::XAttributes(const XAttributes &xa)
-    {
-        y2deb("Entering copy constructor XAttribute(const XAttribute&)");
-        xamap = xa.xamap;
-    }
-
-    XAttributes&
-    XAttributes::operator=(const XAttributes &xa)
-    {
-        y2deb("Entering XAttribute::operator=()");
-        if (this != &xa)
-        {
-            this->xamap = xa.xamap;
-        }
-
-        return *this;
-    }
 
     bool
     XAttributes::operator==(const XAttributes& xa) const

--- a/snapper/XAttributes.h
+++ b/snapper/XAttributes.h
@@ -55,12 +55,10 @@ namespace snapper
             xa_map_t xamap;
         public:
             XAttributes(const string&);
-            XAttributes(const XAttributes&);
 
             xa_map_citer cbegin() const { return xamap.begin(); }
             xa_map_citer cend() const { return xamap.end(); }
 
-            XAttributes& operator=(const XAttributes&);
             bool operator==(const XAttributes&) const;
 	};
 


### PR DESCRIPTION
I'll add my 2 cents to cleanup work. Thank you for noticing all the preceding ones.
