### PR TITLE
Set BACKGROUND_COMPARISON="no" in the default config

### DIFF
--- a/data/default-config
+++ b/data/default-config
@@ -11,7 +11,7 @@ ALLOW_GROUPS=""
 
 # start comparing pre- and post-snapshot in background after creating
 # post-snapshot
-BACKGROUND_COMPARISON="yes"
+BACKGROUND_COMPARISON="no"
 
 
 # run daily number cleanup


### PR DESCRIPTION
The section on `BACKGROUND_COMPARISON` in `snapper-configs(5)` says

```
Default value is "no".
```

but `data/default-config` still has `BACKGROUND_COMPARISON="yes"`.
