### PR TITLE
Fix the CHMOD command for pam_snapper scripts

### DIFF
--- a/scripts/pam_snapper_homeconvert.sh
+++ b/scripts/pam_snapper_homeconvert.sh
@@ -17,7 +17,7 @@ CMD_SED="sed"
 CMD_USERADD="useradd -m"
 CMD_USERDEL="userdel -r"
 CMD_CHOWN="chown"
-CMD_CHOWN="chmod"
+CMD_CHMOD="chmod"
 #
 SNAPPERCFGDIR="/etc/snapper/configs"
 HOMEHOME=/home

--- a/scripts/pam_snapper_useradd.sh
+++ b/scripts/pam_snapper_useradd.sh
@@ -17,7 +17,7 @@ CMD_SED="sed"
 CMD_USERADD="useradd -m"
 CMD_USERDEL="userdel -r"
 CMD_CHOWN="chown"
-CMD_CHOWN="chmod"
+CMD_CHMOD="chmod"
 #
 SNAPPERCFGDIR="/etc/snapper/configs"
 HOMEHOME=/home


### PR DESCRIPTION
Hi,

While packaging snapper for Debian, I noticed a typo in the pam_snapper scripts. Here's a fix.

Thanks,
Nicolas
