### PR TITLE
- extend subvolume instance validity for StreamProcessor.process()

### DIFF
--- a/snapper/Btrfs.cc
+++ b/snapper/Btrfs.cc
@@ -1128,7 +1128,9 @@ namespace snapper
 	{
 	    StopWatch stopwatch;
 
-	    StreamProcessor processor(openSubvolumeDir(), dir1, dir2);
+	    const SDir subvolume(openSubvolumeDir());
+
+	    StreamProcessor processor(subvolume, dir1, dir2);
 
 	    processor.process(cb);
 


### PR DESCRIPTION
Hi Arvin,

what is the problem: they changed the way subvol_uuid_search struct in btrfs-progs is put together (as well as its ABI) in between ad280c1b3a8a88e2113dd1bcb725a36be7da535 and 5f9c5a23e5ff0c5949480ad24a9818c50f5a8dc6.

As a result there's only "root" subvolume fd inside the structure that's supposed to be actually open during  subsequent ioctl call. Unfortunately there's small bug in snapper that causes the root subvolume fd to be closed (SDir base is desroyed) before calling the ioctl to get btrfs diff stream. See that openSubvolumeDir() result is valid only during the StreamProcessor construction. So this fixed the problem described in issue #35 for me.

I dind't know what would for you better, either change the reference inside StreamProcessor to variable or this way...

Hope it'll help.
