### PR TITLE
Add conditionals for btrfs library versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,7 @@ AC_ARG_ENABLE([zypp], AC_HELP_STRING([--disable-zypp],[Disable zypp plugin suppo
 AM_CONDITIONAL(HAVE_ZYPP, [test "x$with_zypp" = "xyes"])
 
 AC_CHECK_LIB(btrfs, btrfs_read_and_process_send_stream)
+AC_CHECK_HEADERS([btrfs/version.h])
 
 AC_ARG_ENABLE([xattrs], AC_HELP_STRING([--disable-xattrs],[Disable extended attributes support]),
 		[with_xattrs=$enableval],[with_xattrs=yes])

--- a/snapper/Btrfs.cc
+++ b/snapper/Btrfs.cc
@@ -34,6 +34,11 @@
 #include <libmount/libmount.h>
 #endif
 #ifdef HAVE_LIBBTRFS
+#ifdef HAVE_BTRFS_VERSION_H
+#include <btrfs/version.h>
+#else
+#define BTRFS_LIB_VERSION (100)
+#endif
 #include <btrfs/ioctl.h>
 #include <btrfs/send.h>
 #include <btrfs/send-stream.h>
@@ -1142,7 +1147,13 @@ namespace snapper
 	    boost::this_thread::interruption_point();
 
 	     // remove the fourth parameter for older versions of libbtrfs
-	    int r = btrfs_read_and_process_send_stream(fd, &send_ops, &*this, 0);
+	    int r;
+
+#if BTRFS_LIB_VERSION < 101
+	    r = btrfs_read_and_process_send_stream(fd, &send_ops, &*this, 0);
+#else
+	    r = btrfs_read_and_process_send_stream(fd, &send_ops, &*this, 0, 1);
+#endif
 
 	    if (r < 0)
 	    {


### PR DESCRIPTION
Currently the btrfs library API is not versioned and causes build
problems. Add a configure-time conditional check for btrfs/version.h
that defines BTRFS_LIB_VERSION, otherwise assume the value 100.

Use it to fix breakage of btrfs_read_and_process_send_stream in
btrfsprogs 3.16.
