### PR TITLE
Install the included systemd units

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -16,6 +16,10 @@ install-data-local:
 	install -D -m 644 x11.txt $(DESTDIR)/etc/snapper/filters/x11.txt
 	install -D -m 644 org.opensuse.Snapper.conf $(DESTDIR)/etc/dbus-1/system.d/org.opensuse.Snapper.conf
 	install -D -m 644 org.opensuse.Snapper.service $(DESTDIR)/usr/share/dbus-1/system-services/org.opensuse.Snapper.service
+	install -D -m 644 cleanup.service $(DESTDIR)/usr/lib/systemd/system/snapper-cleanup.service
+	install -D -m 644 cleanup.timer $(DESTDIR)/usr/lib/systemd/system/snapper-cleanup.timer
+	install -D -m 644 timeline.service $(DESTDIR)/usr/lib/systemd/system/snapper-timeline.service
+	install -D -m 644 timeline.timer $(DESTDIR)/usr/lib/systemd/system/snapper-timeline.timer
 
 if HAVE_ZYPP
 	install -D -m 644 zypp-plugin.conf $(DESTDIR)/etc/snapper/zypp-plugin.conf


### PR DESCRIPTION
Right now the systemd timer units are in the tarball, but aren't actually installed anywhere. This installs them (prefixing "snapper-" to avoid conflicts).