### PR TITLE
Add snapshots creation to installation helpers

### DIFF
--- a/client/installation-helper.cc
+++ b/client/installation-helper.cc
@@ -198,6 +198,7 @@ step4()
 void
 step5(const string& description)
 {
+    // fate #317973
     // step runs in chroot
 
     // preconditions (maybe incomplete):

--- a/client/installation-helper.cc
+++ b/client/installation-helper.cc
@@ -195,6 +195,38 @@ step4()
     cout << "done" << endl;
 }
 
+void
+step5(const string& description)
+{
+    // step runs in chroot
+
+    // preconditions (maybe incomplete):
+    // snapper rpms installed in chroot
+
+    unsigned int num;
+
+    SCD scd;
+    scd.read_only = false;
+    scd.description = description;
+
+    Snapper snapper("root", "/");
+
+    try
+    {
+        Snapshots::iterator snapshot = snapper.createSingleSnapshot(scd);
+        num = snapshot->getNum();
+        snapper.getFilesystem()->setDefault(num);
+    }
+    catch (const runtime_error& e)
+    {
+        y2err("create snapshot failed, " << e.what());
+        exit(EXIT_FAILURE);
+    }
+
+    cout << num << endl;
+    exit(EXIT_SUCCESS);
+}
+
 
 void
 log_do(LogLevel level, const string& component, const char* file, const int line, const char* func,
@@ -270,4 +302,6 @@ main(int argc, char** argv)
 	step3(root_prefix, default_subvolume_name);
     else if (step == "4")
 	step4();
+    else if (step == "5")
+	step5(description);
 }

--- a/client/installation-helper.cc
+++ b/client/installation-helper.cc
@@ -195,15 +195,15 @@ step4()
     cout << "done" << endl;
 }
 
-void
-step5(const string& root_prefix, const string& snapshot_type, unsigned int pre_num, const string& description, const map<string, string>& userdata)
+int
+step5(const string& root_prefix, const string& description, const string& snapshot_type,
+    unsigned int pre_num, const map<string, string>& userdata)
 {
     // fate #317973
 
     // preconditions (maybe incomplete):
     // snapper rpms installed
 
-    unsigned int num;
     Snapshots::iterator snapshot;
     SCD scd;
 
@@ -228,11 +228,11 @@ step5(const string& root_prefix, const string& snapshot_type, unsigned int pre_n
     catch (const runtime_error& e)
     {
         y2err("create snapshot failed, " << e.what());
-        exit(EXIT_FAILURE);
+        return EXIT_FAILURE;
     }
 
     cout << snapshot->getNum() << endl;
-    exit(EXIT_SUCCESS);
+    return EXIT_SUCCESS;
 }
 
 
@@ -277,7 +277,7 @@ main(int argc, char** argv)
     string default_subvolume_name;
     string description;
     string snapshot_type = "single";
-    unsigned int pre_num;
+    unsigned int pre_num = 0;
     map<string, string> userdata;
 
     GetOpts getopts;
@@ -321,5 +321,5 @@ main(int argc, char** argv)
     else if (step == "4")
 	step4();
     else if (step == "5")
-	step5(root_prefix, snapshot_type, pre_num, description, userdata);
+	exit(step5(root_prefix, description, snapshot_type, pre_num, userdata));
 }

--- a/client/installation-helper.cc
+++ b/client/installation-helper.cc
@@ -195,7 +195,7 @@ step4()
     cout << "done" << endl;
 }
 
-int
+bool
 step5(const string& root_prefix, const string& description, const string& snapshot_type,
     unsigned int pre_num, const map<string, string>& userdata)
 {
@@ -228,11 +228,11 @@ step5(const string& root_prefix, const string& description, const string& snapsh
     catch (const runtime_error& e)
     {
         y2err("create snapshot failed, " << e.what());
-        return EXIT_FAILURE;
+        return false;
     }
 
     cout << snapshot->getNum() << endl;
-    return EXIT_SUCCESS;
+    return true;
 }
 
 
@@ -321,5 +321,5 @@ main(int argc, char** argv)
     else if (step == "4")
 	step4();
     else if (step == "5")
-	exit(step5(root_prefix, description, snapshot_type, pre_num, userdata));
+	return step5(root_prefix, description, snapshot_type, pre_num, userdata) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 18 14:38:17 UTC 2015 - igonzalezsosa@suse.com
+
+- added a helper to create snapshots without D-Bus
+  during system installation/upgrade (fate#317973)
+
+-------------------------------------------------------------------
 Tue May 05 14:08:03 CEST 2015 - aschnell@suse.de
 
 - added option --sync to delete command (fate#317066)


### PR DESCRIPTION
Add a new step to installation helpers to create an snapshot without D-Bus (to be used during installation). It's will be used by yast-yast2 (see yast/yast-yast2#352 for more information).