### PR TITLE
Handle fpathconf() errors.

### DIFF
--- a/snapper/FileUtils.cc
+++ b/snapper/FileUtils.cc
@@ -207,7 +207,10 @@ namespace snapper
 
 	vector<string> ret;
 
-	size_t len = offsetof(struct dirent, d_name) + fpathconf(dirfd, _PC_NAME_MAX) + 1;
+	long sz = fpathconf(dirfd, _PC_NAME_MAX);
+	if (sz == -1)
+	    sz = NAME_MAX;
+	size_t len = offsetof(struct dirent, d_name) + sz + 1;
 	struct dirent* ep = (struct dirent*) malloc(len);
 	struct dirent* epp;
 


### PR DESCRIPTION
In one place snapper calls fpathconf(.., _PC_NAME_MAX) to determine the size of
a buffer used to hold readdir_r() results.  fpathconf() may return -1 on error,
but this fpathconf() call's return value is unchecked.  This can result in
allocating a buffer that is too small for readdir_r()'s results, resulting in
out-of-bounds memory access.

Fix it by falling back to using NAME_MAX if fpathconf(.., _PC_NAME_MAX) fails.

Signed-off-by: Justin Maggard <jmaggard@netgear.com>