### PR TITLE
Verbose delete, try 3

### DIFF
--- a/client/cleanup.cc
+++ b/client/cleanup.cc
@@ -94,7 +94,7 @@ is_important(XSnapshots::const_iterator it1)
 
 
 bool
-do_cleanup_number(DBus::Connection& conn, const string& config_name)
+do_cleanup_number(DBus::Connection& conn, const string& config_name, bool verbose)
 {
     time_t min_age = 1800;
     size_t limit = 50;
@@ -153,7 +153,7 @@ do_cleanup_number(DBus::Connection& conn, const string& config_name)
     {
 	list<unsigned int> nums;
 	nums.push_back((*it)->getNum());
-	command_delete_xsnapshots(conn, config_name, nums, false);
+	command_delete_xsnapshots(conn, config_name, nums, verbose);
     }
 
     return true;
@@ -232,7 +232,7 @@ is_first_hourly(list<XSnapshots::const_iterator>::const_iterator first,
 
 
 bool
-do_cleanup_timeline(DBus::Connection& conn, const string& config_name)
+do_cleanup_timeline(DBus::Connection& conn, const string& config_name, bool verbose)
 {
     time_t min_age = 1800;
     size_t limit_hourly = 10;
@@ -318,7 +318,7 @@ do_cleanup_timeline(DBus::Connection& conn, const string& config_name)
     {
 	list<unsigned int> nums;
 	nums.push_back((*it)->getNum());
-	command_delete_xsnapshots(conn, config_name, nums, false);
+	command_delete_xsnapshots(conn, config_name, nums, verbose);
     }
 
     return true;
@@ -326,7 +326,7 @@ do_cleanup_timeline(DBus::Connection& conn, const string& config_name)
 
 
 bool
-do_cleanup_empty_pre_post(DBus::Connection& conn, const string& config_name)
+do_cleanup_empty_pre_post(DBus::Connection& conn, const string& config_name, bool verbose)
 {
     time_t min_age = 1800;
 
@@ -369,7 +369,7 @@ do_cleanup_empty_pre_post(DBus::Connection& conn, const string& config_name)
     {
 	list<unsigned int> nums;
 	nums.push_back((*it)->getNum());
-	command_delete_xsnapshots(conn, config_name, nums, false);
+	command_delete_xsnapshots(conn, config_name, nums, verbose);
     }
 
     return true;

--- a/client/cleanup.cc
+++ b/client/cleanup.cc
@@ -153,7 +153,7 @@ do_cleanup_number(DBus::Connection& conn, const string& config_name)
     {
 	list<unsigned int> nums;
 	nums.push_back((*it)->getNum());
-	command_delete_xsnapshots(conn, config_name, nums);
+	command_delete_xsnapshots(conn, config_name, nums, false);
     }
 
     return true;
@@ -318,7 +318,7 @@ do_cleanup_timeline(DBus::Connection& conn, const string& config_name)
     {
 	list<unsigned int> nums;
 	nums.push_back((*it)->getNum());
-	command_delete_xsnapshots(conn, config_name, nums);
+	command_delete_xsnapshots(conn, config_name, nums, false);
     }
 
     return true;
@@ -369,7 +369,7 @@ do_cleanup_empty_pre_post(DBus::Connection& conn, const string& config_name)
     {
 	list<unsigned int> nums;
 	nums.push_back((*it)->getNum());
-	command_delete_xsnapshots(conn, config_name, nums);
+	command_delete_xsnapshots(conn, config_name, nums, false);
     }
 
     return true;

--- a/client/cleanup.h
+++ b/client/cleanup.h
@@ -21,10 +21,10 @@
 
 
 bool
-do_cleanup_number(DBus::Connection& conn, const string& config_name);
+do_cleanup_number(DBus::Connection& conn, const string& config_name, bool verbose);
 
 bool
-do_cleanup_timeline(DBus::Connection& conn, const string& config_name);
+do_cleanup_timeline(DBus::Connection& conn, const string& config_name, bool verbose);
 
 bool
-do_cleanup_empty_pre_post(DBus::Connection& conn, const string& config_name);
+do_cleanup_empty_pre_post(DBus::Connection& conn, const string& config_name, bool verbose);

--- a/client/commands.cc
+++ b/client/commands.cc
@@ -21,6 +21,8 @@
 
 
 #include "commands.h"
+#include "utils/text.h"
+#include "misc.h"
 
 
 #define SERVICE "org.opensuse.Snapper"
@@ -267,6 +269,16 @@ command_delete_xsnapshots(DBus::Connection& conn, const string& config_name,
 
     DBus::Hoho hoho(call);
     hoho << config_name << nums;
+
+    if (verbose) {
+	cout << _("Deleting snapshots from ") << config_name << ": ";
+	for (list<unsigned int>::const_iterator it = nums.begin(); it != nums.end(); ++it) {
+	    if (it != nums.begin())
+		cout << ", ";
+	    cout << *it;
+	}
+	cout << endl;
+    }
 
     conn.send_with_reply_and_block(call);
 }

--- a/client/commands.cc
+++ b/client/commands.cc
@@ -261,7 +261,7 @@ command_create_post_xsnapshot(DBus::Connection& conn, const string& config_name,
 
 void
 command_delete_xsnapshots(DBus::Connection& conn, const string& config_name,
-			  list<unsigned int> nums)
+			  list<unsigned int> nums, bool verbose)
 {
     DBus::MessageMethodCall call(SERVICE, OBJECT, INTERFACE, "DeleteSnapshots");
 

--- a/client/commands.h
+++ b/client/commands.h
@@ -89,7 +89,7 @@ command_create_post_xsnapshot(DBus::Connection& conn, const string& config_name,
 
 void
 command_delete_xsnapshots(DBus::Connection& conn, const string& config_name,
-			  list<unsigned int> nums);
+			  list<unsigned int> nums, bool verbose);
 
 string
 command_mount_xsnapshots(DBus::Connection& conn, const string& config_name,

--- a/client/snapper.cc
+++ b/client/snapper.cc
@@ -938,7 +938,7 @@ command_delete(DBus::Connection* conn, Snapper* snapper)
 	}
     }
 
-    command_delete_xsnapshots(*conn, config_name, nums);
+    command_delete_xsnapshots(*conn, config_name, nums, verbose);
 
     if (sync)
 	command_xsync(*conn, config_name);

--- a/client/snapper.cc
+++ b/client/snapper.cc
@@ -1420,15 +1420,15 @@ command_cleanup(DBus::Connection* conn, Snapper* snapper)
 
     if (cleanup == "number")
     {
-	do_cleanup_number(*conn, config_name);
+	do_cleanup_number(*conn, config_name, verbose);
     }
     else if (cleanup == "timeline")
     {
-	do_cleanup_timeline(*conn, config_name);
+	do_cleanup_timeline(*conn, config_name, verbose);
     }
     else if (cleanup == "empty-pre-post")
     {
-	do_cleanup_empty_pre_post(*conn, config_name);
+	do_cleanup_empty_pre_post(*conn, config_name, verbose);
     }
     else
     {

--- a/client/systemd-helper.cc
+++ b/client/systemd-helper.cc
@@ -67,19 +67,19 @@ cleanup(DBus::Connection* conn)
 	map<string, string>::const_iterator pos1 = config_info.raw.find("NUMBER_CLEANUP");
 	if (pos1 != config_info.raw.end() && pos1->second == "yes")
 	{
-	    do_cleanup_number(*conn, config_info.config_name);
+	    do_cleanup_number(*conn, config_info.config_name, false);
 	}
 
 	map<string, string>::const_iterator pos2 = config_info.raw.find("TIMELINE_CLEANUP");
 	if (pos2 != config_info.raw.end() && pos2->second == "yes")
 	{
-	    do_cleanup_timeline(*conn, config_info.config_name);
+	    do_cleanup_timeline(*conn, config_info.config_name, false);
 	}
 
 	map<string, string>::const_iterator pos3 = config_info.raw.find("EMPTY_PRE_POST_CLEANUP");
 	if (pos3 != config_info.raw.end() && pos3->second == "yes")
 	{
-	    do_cleanup_empty_pre_post(*conn, config_info.config_name);
+	    do_cleanup_empty_pre_post(*conn, config_info.config_name, false);
 	}
     }
 }


### PR DESCRIPTION
This is a serie patches to produce verbose output if using arg -v to
snapper cleanup, or snapper delete.