### PR TITLE
Install systemd-helper to libexecdir rather than /usr/lib

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -18,7 +18,7 @@ snapper_SOURCES =			\
 
 snapper_LDADD = ../snapper/libsnapper.la utils/libutils.la ../dbus/libdbus.la
 
-libexecdir = /usr/lib/snapper
+libexecdir = @libexecdir@/snapper
 
 libexec_PROGRAMS = systemd-helper
 

--- a/configure.ac
+++ b/configure.ac
@@ -160,6 +160,7 @@ AC_OUTPUT(
 	scripts/Makefile
 	pam/Makefile
 	data/Makefile
+	data/timeline.service:data/timeline.service.in
 	doc/Makefile
 	doc/snapper.xml:doc/snapper.xml.in
 	doc/snapperd.xml:doc/snapperd.xml.in

--- a/configure.ac
+++ b/configure.ac
@@ -160,6 +160,7 @@ AC_OUTPUT(
 	scripts/Makefile
 	pam/Makefile
 	data/Makefile
+	data/cleanup.service:data/cleanup.service.in
 	data/timeline.service:data/timeline.service.in
 	doc/Makefile
 	doc/snapper.xml:doc/snapper.xml.in

--- a/data/cleanup.service.in
+++ b/data/cleanup.service.in
@@ -5,5 +5,5 @@ Documentation=man:snapper(8) man:snapper-configs(5)
 
 [Service]
 Type=simple
-ExecStart=/usr/lib/snapper/systemd-helper --cleanup
+ExecStart=@libexecdir@/snapper/systemd-helper --cleanup
 

--- a/data/timeline.service.in
+++ b/data/timeline.service.in
@@ -5,5 +5,5 @@ Documentation=man:snapper(8) man:snapper-configs(5)
 
 [Service]
 Type=simple
-ExecStart=/usr/lib/snapper/systemd-helper --timeline
+ExecStart=@libexecdir@/snapper/systemd-helper --timeline
 

--- a/snapper.spec.in
+++ b/snapper.spec.in
@@ -86,7 +86,7 @@ autoconf
 	--disable-rollback							\
 %endif
 	--disable-silent-rules --disable-ext4 --disable-btrfs-quota
-make %{?jobs:-j%jobs}
+make %{?_smp_mflags}
 
 %install
 make install DESTDIR="$RPM_BUILD_ROOT"
@@ -111,7 +111,7 @@ rm -rf "$RPM_BUILD_ROOT"
 %{prefix}/bin/snapper
 %{prefix}/sbin/snapperd
 %{prefix}/sbin/mksubvolume
-%{prefix}/lib/snapper
+%{_libexecdir}/snapper
 %doc %{_mandir}/*/snapper.8*
 %doc %{_mandir}/*/snapperd.8*
 %doc %{_mandir}/*/snapper-configs.5*

--- a/snapper.spec.in
+++ b/snapper.spec.in
@@ -81,7 +81,7 @@ automake --add-missing --copy
 autoconf
 
 ./configure --libdir=%{_libdir} --prefix=%{prefix} --mandir=%{_mandir}		\
-	--docdir=%{prefix}/share/doc/packages/snapper				\
+	--docdir=%{prefix}/share/doc/packages/snapper --libexecdir=%{_libexecdir} \
 %if 0%{?suse_version} <= 1310
 	--disable-rollback							\
 %endif


### PR DESCRIPTION
To be properly conforming to FHS, the systemd-helper is now installed to wherever the system defines `@libexecdir@`.

This fixes #179.