### PR TITLE
Fix build on debian: add missing linker arguments.

### DIFF
--- a/examples/c++-lib/Makefile.am
+++ b/examples/c++-lib/Makefile.am
@@ -15,6 +15,7 @@ ListAll_SOURCES = ListAll.cc
 Create_SOURCES = Create.cc
 
 CmpDirs_SOURCES = CmpDirs.cc
+CmpDirs_LDADD = $(LDADD) -lboost_system
 
 CreateNumber_SOURCES = CreateNumber.cc
 

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -13,5 +13,5 @@ snapperd_SOURCES =					\
 	Background.cc		Background.h		\
 	Types.cc		Types.h
 
-snapperd_LDADD = ../snapper/libsnapper.la ../dbus/libdbus.la -lrt
-
+snapperd_LDADD = ../snapper/libsnapper.la ../dbus/libdbus.la -lrt	\
+	-lboost_thread -lboost_system

--- a/testsuite-cmp/Makefile.am
+++ b/testsuite-cmp/Makefile.am
@@ -11,6 +11,7 @@ noinst_SCRIPTS = run-all
 noinst_PROGRAMS = cmp
 
 cmp_SOURCES = cmp.cc
+cmp_LDADD = $(LDADD) -lboost_system
 
 EXTRA_DIST = $(noinst_SCRIPTS)
 


### PR DESCRIPTION
In Debian testing snapper fais to build returning linking errors caused by missing symbols from Boost library. For example:

````
  CXXLD    snapperd
/usr/bin/ld: Client.o: undefined reference to symbol '_ZTVN5boost6detail16thread_data_baseE'
//usr/lib/x86_64-linux-gnu/libboost_thread.so.1.58.0: error adding symbols: DSO missing from command line
````

To reproduce:
````bash
# prepare fresh debian testing instance for example using docker
docker pull debian:testing
docker run -t -i debian:testing /bin/bash

# inside fresh debian testing instance install all deps
apt-get update
apt-get -y upgrade
apt-get -y install git autoconf libtool make g++ libc-dev libmount-dev 	\
	libdbus-1-dev libacl1-dev libxml2-dev libboost-thread1.58-dev 	\
	libboost-system1.58-dev zlib1g-dev btrfs-tools e2fslibs-dev 	\
	libpam0g-dev docbook-xsl xsltproc gettext

# try to build snapper
git clone https://github.com/openSUSE/snapper.git
cd snapper
make -f Makefile.repo
make
````

I don't know what is the root cause and why it compiles without problems in your OBS. I hope my attitude to this problem is correct.