### PR TITLE
Support platforms using musl libc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,7 @@ SUBDIRS = snapper examples dbus server client scripts pam data doc po		\
 	testsuite testsuite-real testsuite-cmp
 
 AUTOMAKE_OPTIONS = foreign dist-bzip2 no-dist-gzip
+ACLOCAL_AMFLAGS = -Im4
 
 doc_DATA = AUTHORS COPYING
 

--- a/client/utils/equal-date.cc
+++ b/client/utils/equal-date.cc
@@ -24,6 +24,8 @@
 
 #include "equal-date.h"
 
+#define isleapyear(year) \
+    ((year) % 4 == 0 && ((year) % 100 != 0 || (year) % 400 == 0))
 
 int
 yday_of_weeks_monday(const struct tm& tmp)
@@ -35,7 +37,7 @@ yday_of_weeks_monday(const struct tm& tmp)
 int
 days_in_year(const struct tm& tmp)
 {
-    return __isleap(tmp.tm_year) ? 366 : 365;
+    return isleapyear(tmp.tm_year) ? 366 : 365;
 }
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,7 @@ AC_CONFIG_HEADERS(config.h)
 AC_DISABLE_STATIC
 
 AC_PROG_CXX
+AC_LANG([C++])
 LT_INIT
 
 AC_PREFIX_DEFAULT(/usr)
@@ -137,6 +138,20 @@ AM_CONDITIONAL(HAVE_PAM, [test "x$with_pam" = "xyes"])
 PKG_CHECK_MODULES(DBUS, dbus-1)
 
 AC_CHECK_HEADER(acl/libacl.h,[],[AC_MSG_ERROR([Cannout find libacl headers. Please install libacl-devel])])
+
+AC_MSG_CHECKING([if the GNU variant of strerror_r is available])
+AC_COMPILE_IFELSE([
+    AC_LANG_SOURCE([
+        [#include <string.h>]
+        [int main() { int (*cb) (int, char *, size_t) = strerror_r; (void) cb; return 0; }]
+    ])
+], [gnu_strerror_r=no], [gnu_strerror_r=yes])
+AC_MSG_RESULT($gnu_strerror_r)
+
+
+AS_IF([test "x$gnu_strerror_r" = "xyes"], [
+    AC_DEFINE(HAVE_GNU_STRERROR_R, 1, [Use GNU variant of strerror_r])
+])
 
 AC_SUBST(VERSION)
 AC_SUBST(LIBVERSION_MAJOR)

--- a/configure.ac
+++ b/configure.ac
@@ -141,6 +141,9 @@ PKG_CHECK_MODULES(DBUS, dbus-1)
 
 AC_CHECK_HEADER(acl/libacl.h,[],[AC_MSG_ERROR([Cannout find libacl headers. Please install libacl-devel])])
 
+AM_GNU_GETTEXT_VERSION([0.18.1])
+AM_GNU_GETTEXT([external])
+
 AX_BOOST_BASE([1.40], [has_boost=yes], [AC_MSG_ERROR(["Cannot find boost headers. Please ensure that the headers are installed at a known location or provide the installation directory via --with-boost"])])
 AX_BOOST_SYSTEM
 AX_BOOST_THREAD

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,8 @@
 
 AC_INIT(snapper/Snapper.h)
 
+AC_CONFIG_MACRO_DIR([m4])
+
 VERSION=`cat ./VERSION`
 
 LIBVERSION=`cat ./LIBVERSION`
@@ -138,6 +140,10 @@ AM_CONDITIONAL(HAVE_PAM, [test "x$with_pam" = "xyes"])
 PKG_CHECK_MODULES(DBUS, dbus-1)
 
 AC_CHECK_HEADER(acl/libacl.h,[],[AC_MSG_ERROR([Cannout find libacl headers. Please install libacl-devel])])
+
+AX_BOOST_BASE([1.40], [has_boost=yes], [AC_MSG_ERROR(["Cannot find boost headers. Please ensure that the headers are installed at a known location or provide the installation directory via --with-boost"])])
+AX_BOOST_SYSTEM
+AX_BOOST_THREAD
 
 AC_MSG_CHECKING([if the GNU variant of strerror_r is available])
 AC_COMPILE_IFELSE([

--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -1,0 +1,285 @@
+# ===========================================================================
+#       http://www.gnu.org/software/autoconf-archive/ax_boost_base.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_BASE([MINIMUM-VERSION], [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+#
+# DESCRIPTION
+#
+#   Test for the Boost C++ libraries of a particular version (or newer)
+#
+#   If no path to the installed boost library is given the macro searchs
+#   under /usr, /usr/local, /opt and /opt/local and evaluates the
+#   $BOOST_ROOT environment variable. Further documentation is available at
+#   <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_CPPFLAGS) / AC_SUBST(BOOST_LDFLAGS)
+#
+#   And sets:
+#
+#     HAVE_BOOST
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2009 Peter Adolphs
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 26
+
+AC_DEFUN([AX_BOOST_BASE],
+[
+AC_ARG_WITH([boost],
+  [AS_HELP_STRING([--with-boost@<:@=ARG@:>@],
+    [use Boost library from a standard location (ARG=yes),
+     from the specified location (ARG=<path>),
+     or disable it (ARG=no)
+     @<:@ARG=yes@:>@ ])],
+    [
+    if test "$withval" = "no"; then
+        want_boost="no"
+    elif test "$withval" = "yes"; then
+        want_boost="yes"
+        ac_boost_path=""
+    else
+        want_boost="yes"
+        ac_boost_path="$withval"
+    fi
+    ],
+    [want_boost="yes"])
+
+
+AC_ARG_WITH([boost-libdir],
+        AS_HELP_STRING([--with-boost-libdir=LIB_DIR],
+        [Force given directory for boost libraries. Note that this will override library path detection, so use this parameter only if default library detection fails and you know exactly where your boost libraries are located.]),
+        [
+        if test -d "$withval"
+        then
+                ac_boost_lib_path="$withval"
+        else
+                AC_MSG_ERROR(--with-boost-libdir expected directory name)
+        fi
+        ],
+        [ac_boost_lib_path=""]
+)
+
+if test "x$want_boost" = "xyes"; then
+    boost_lib_version_req=ifelse([$1], ,1.20.0,$1)
+    boost_lib_version_req_shorten=`expr $boost_lib_version_req : '\([[0-9]]*\.[[0-9]]*\)'`
+    boost_lib_version_req_major=`expr $boost_lib_version_req : '\([[0-9]]*\)'`
+    boost_lib_version_req_minor=`expr $boost_lib_version_req : '[[0-9]]*\.\([[0-9]]*\)'`
+    boost_lib_version_req_sub_minor=`expr $boost_lib_version_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
+    if test "x$boost_lib_version_req_sub_minor" = "x" ; then
+        boost_lib_version_req_sub_minor="0"
+        fi
+    WANT_BOOST_VERSION=`expr $boost_lib_version_req_major \* 100000 \+  $boost_lib_version_req_minor \* 100 \+ $boost_lib_version_req_sub_minor`
+    AC_MSG_CHECKING(for boostlib >= $boost_lib_version_req)
+    succeeded=no
+
+    dnl On 64-bit systems check for system libraries in both lib64 and lib.
+    dnl The former is specified by FHS, but e.g. Debian does not adhere to
+    dnl this (as it rises problems for generic multi-arch support).
+    dnl The last entry in the list is chosen by default when no libraries
+    dnl are found, e.g. when only header-only libraries are installed!
+    libsubdirs="lib"
+    ax_arch=`uname -m`
+    case $ax_arch in
+      x86_64)
+        libsubdirs="lib64 libx32 lib lib64"
+        ;;
+      ppc64|s390x|sparc64|aarch64|ppc64le)
+        libsubdirs="lib64 lib lib64 ppc64le"
+        ;;
+    esac
+
+    dnl allow for real multi-arch paths e.g. /usr/lib/x86_64-linux-gnu. Give
+    dnl them priority over the other paths since, if libs are found there, they
+    dnl are almost assuredly the ones desired.
+    AC_REQUIRE([AC_CANONICAL_HOST])
+    libsubdirs="lib/${host_cpu}-${host_os} $libsubdirs"
+
+    case ${host_cpu} in
+      i?86)
+        libsubdirs="lib/i386-${host_os} $libsubdirs"
+        ;;
+    esac
+
+    dnl first we check the system location for boost libraries
+    dnl this location ist chosen if boost libraries are installed with the --layout=system option
+    dnl or if you install boost with RPM
+    if test "$ac_boost_path" != ""; then
+        BOOST_CPPFLAGS="-I$ac_boost_path/include"
+        for ac_boost_path_tmp in $libsubdirs; do
+                if test -d "$ac_boost_path"/"$ac_boost_path_tmp" ; then
+                        BOOST_LDFLAGS="-L$ac_boost_path/$ac_boost_path_tmp"
+                        break
+                fi
+        done
+    elif test "$cross_compiling" != yes; then
+        for ac_boost_path_tmp in /usr /usr/local /opt /opt/local ; do
+            if test -d "$ac_boost_path_tmp/include/boost" && test -r "$ac_boost_path_tmp/include/boost"; then
+                for libsubdir in $libsubdirs ; do
+                    if ls "$ac_boost_path_tmp/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                done
+                BOOST_LDFLAGS="-L$ac_boost_path_tmp/$libsubdir"
+                BOOST_CPPFLAGS="-I$ac_boost_path_tmp/include"
+                break;
+            fi
+        done
+    fi
+
+    dnl overwrite ld flags if we have required special directory with
+    dnl --with-boost-libdir parameter
+    if test "$ac_boost_lib_path" != ""; then
+       BOOST_LDFLAGS="-L$ac_boost_lib_path"
+    fi
+
+    CPPFLAGS_SAVED="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+    export CPPFLAGS
+
+    LDFLAGS_SAVED="$LDFLAGS"
+    LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+    export LDFLAGS
+
+    AC_REQUIRE([AC_PROG_CXX])
+    AC_LANG_PUSH(C++)
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    @%:@include <boost/version.hpp>
+    ]], [[
+    #if BOOST_VERSION >= $WANT_BOOST_VERSION
+    // Everything is okay
+    #else
+    #  error Boost version is too old
+    #endif
+    ]])],[
+        AC_MSG_RESULT(yes)
+    succeeded=yes
+    found_system=yes
+        ],[
+        ])
+    AC_LANG_POP([C++])
+
+
+
+    dnl if we found no boost with system layout we search for boost libraries
+    dnl built and installed without the --layout=system option or for a staged(not installed) version
+    if test "x$succeeded" != "xyes"; then
+        CPPFLAGS="$CPPFLAGS_SAVED"
+        LDFLAGS="$LDFLAGS_SAVED"
+        BOOST_CPPFLAGS=
+        BOOST_LDFLAGS=
+        _version=0
+        if test "$ac_boost_path" != ""; then
+            if test -d "$ac_boost_path" && test -r "$ac_boost_path"; then
+                for i in `ls -d $ac_boost_path/include/boost-* 2>/dev/null`; do
+                    _version_tmp=`echo $i | sed "s#$ac_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
+                    V_CHECK=`expr $_version_tmp \> $_version`
+                    if test "$V_CHECK" = "1" ; then
+                        _version=$_version_tmp
+                    fi
+                    VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
+                    BOOST_CPPFLAGS="-I$ac_boost_path/include/boost-$VERSION_UNDERSCORE"
+                done
+                dnl if nothing found search for layout used in Windows distributions
+                if test -z "$BOOST_CPPFLAGS"; then
+                    if test -d "$ac_boost_path/boost" && test -r "$ac_boost_path/boost"; then
+                        BOOST_CPPFLAGS="-I$ac_boost_path"
+                    fi
+                fi
+            fi
+        else
+            if test "$cross_compiling" != yes; then
+                for ac_boost_path in /usr /usr/local /opt /opt/local ; do
+                    if test -d "$ac_boost_path" && test -r "$ac_boost_path"; then
+                        for i in `ls -d $ac_boost_path/include/boost-* 2>/dev/null`; do
+                            _version_tmp=`echo $i | sed "s#$ac_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
+                            V_CHECK=`expr $_version_tmp \> $_version`
+                            if test "$V_CHECK" = "1" ; then
+                                _version=$_version_tmp
+                                best_path=$ac_boost_path
+                            fi
+                        done
+                    fi
+                done
+
+                VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
+                BOOST_CPPFLAGS="-I$best_path/include/boost-$VERSION_UNDERSCORE"
+                if test "$ac_boost_lib_path" = ""; then
+                    for libsubdir in $libsubdirs ; do
+                        if ls "$best_path/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                    done
+                    BOOST_LDFLAGS="-L$best_path/$libsubdir"
+                fi
+            fi
+
+            if test "x$BOOST_ROOT" != "x"; then
+                for libsubdir in $libsubdirs ; do
+                    if ls "$BOOST_ROOT/stage/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                done
+                if test -d "$BOOST_ROOT" && test -r "$BOOST_ROOT" && test -d "$BOOST_ROOT/stage/$libsubdir" && test -r "$BOOST_ROOT/stage/$libsubdir"; then
+                    version_dir=`expr //$BOOST_ROOT : '.*/\(.*\)'`
+                    stage_version=`echo $version_dir | sed 's/boost_//' | sed 's/_/./g'`
+                        stage_version_shorten=`expr $stage_version : '\([[0-9]]*\.[[0-9]]*\)'`
+                    V_CHECK=`expr $stage_version_shorten \>\= $_version`
+                    if test "$V_CHECK" = "1" -a "$ac_boost_lib_path" = "" ; then
+                        AC_MSG_NOTICE(We will use a staged boost library from $BOOST_ROOT)
+                        BOOST_CPPFLAGS="-I$BOOST_ROOT"
+                        BOOST_LDFLAGS="-L$BOOST_ROOT/stage/$libsubdir"
+                    fi
+                fi
+            fi
+        fi
+
+        CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+        export CPPFLAGS
+        LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+        export LDFLAGS
+
+        AC_LANG_PUSH(C++)
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+        @%:@include <boost/version.hpp>
+        ]], [[
+        #if BOOST_VERSION >= $WANT_BOOST_VERSION
+        // Everything is okay
+        #else
+        #  error Boost version is too old
+        #endif
+        ]])],[
+            AC_MSG_RESULT(yes)
+        succeeded=yes
+        found_system=yes
+            ],[
+            ])
+        AC_LANG_POP([C++])
+    fi
+
+    if test "$succeeded" != "yes" ; then
+        if test "$_version" = "0" ; then
+            AC_MSG_NOTICE([[We could not detect the boost libraries (version $boost_lib_version_req_shorten or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.]])
+        else
+            AC_MSG_NOTICE([Your boost libraries seems to old (version $_version).])
+        fi
+        # execute ACTION-IF-NOT-FOUND (if present):
+        ifelse([$3], , :, [$3])
+    else
+        AC_SUBST(BOOST_CPPFLAGS)
+        AC_SUBST(BOOST_LDFLAGS)
+        AC_DEFINE(HAVE_BOOST,,[define if the Boost library is available])
+        # execute ACTION-IF-FOUND (if present):
+        ifelse([$2], , :, [$2])
+    fi
+
+    CPPFLAGS="$CPPFLAGS_SAVED"
+    LDFLAGS="$LDFLAGS_SAVED"
+fi
+
+])

--- a/m4/ax_boost_system.m4
+++ b/m4/ax_boost_system.m4
@@ -1,0 +1,120 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_boost_system.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_SYSTEM
+#
+# DESCRIPTION
+#
+#   Test for System library from the Boost C++ libraries. The macro requires
+#   a preceding call to AX_BOOST_BASE. Further documentation is available at
+#   <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_SYSTEM_LIB)
+#
+#   And sets:
+#
+#     HAVE_BOOST_SYSTEM
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2008 Michael Tindal
+#   Copyright (c) 2008 Daniel Casimiro <dan.casimiro@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 17
+
+AC_DEFUN([AX_BOOST_SYSTEM],
+[
+	AC_ARG_WITH([boost-system],
+	AS_HELP_STRING([--with-boost-system@<:@=special-lib@:>@],
+                   [use the System library from boost - it is possible to specify a certain library for the linker
+                        e.g. --with-boost-system=boost_system-gcc-mt ]),
+        [
+        if test "$withval" = "no"; then
+			want_boost="no"
+        elif test "$withval" = "yes"; then
+            want_boost="yes"
+            ax_boost_user_system_lib=""
+        else
+		    want_boost="yes"
+		ax_boost_user_system_lib="$withval"
+		fi
+        ],
+        [want_boost="yes"]
+	)
+
+	if test "x$want_boost" = "xyes"; then
+        AC_REQUIRE([AC_PROG_CC])
+        AC_REQUIRE([AC_CANONICAL_BUILD])
+		CPPFLAGS_SAVED="$CPPFLAGS"
+		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+		export CPPFLAGS
+
+		LDFLAGS_SAVED="$LDFLAGS"
+		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+		export LDFLAGS
+
+        AC_CACHE_CHECK(whether the Boost::System library is available,
+					   ax_cv_boost_system,
+        [AC_LANG_PUSH([C++])
+			 CXXFLAGS_SAVE=$CXXFLAGS
+
+			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/system/error_code.hpp>]],
+                                   [[boost::system::system_category]])],
+                   ax_cv_boost_system=yes, ax_cv_boost_system=no)
+			 CXXFLAGS=$CXXFLAGS_SAVE
+             AC_LANG_POP([C++])
+		])
+		if test "x$ax_cv_boost_system" = "xyes"; then
+			AC_SUBST(BOOST_CPPFLAGS)
+
+			AC_DEFINE(HAVE_BOOST_SYSTEM,,[define if the Boost::System library is available])
+            BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
+
+			LDFLAGS_SAVE=$LDFLAGS
+            if test "x$ax_boost_user_system_lib" = "x"; then
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_system* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
+                                 [link_system="no"])
+				done
+                if test "x$link_system" != "xyes"; then
+                for libextension in `ls -r $BOOSTLIBDIR/boost_system* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
+                                 [link_system="no"])
+				done
+                fi
+
+            else
+               for ax_lib in $ax_boost_user_system_lib boost_system-$ax_boost_user_system_lib; do
+				      AC_CHECK_LIB($ax_lib, exit,
+                                   [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
+                                   [link_system="no"])
+                  done
+
+            fi
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
+            fi
+			if test "x$link_system" = "xno"; then
+				AC_MSG_ERROR(Could not link against $ax_lib !)
+			fi
+		fi
+
+		CPPFLAGS="$CPPFLAGS_SAVED"
+	LDFLAGS="$LDFLAGS_SAVED"
+	fi
+])

--- a/m4/ax_boost_thread.m4
+++ b/m4/ax_boost_thread.m4
@@ -1,0 +1,149 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_boost_thread.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_THREAD
+#
+# DESCRIPTION
+#
+#   Test for Thread library from the Boost C++ libraries. The macro requires
+#   a preceding call to AX_BOOST_BASE. Further documentation is available at
+#   <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_THREAD_LIB)
+#
+#   And sets:
+#
+#     HAVE_BOOST_THREAD
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2009 Michael Tindal
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 27
+
+AC_DEFUN([AX_BOOST_THREAD],
+[
+	AC_ARG_WITH([boost-thread],
+	AS_HELP_STRING([--with-boost-thread@<:@=special-lib@:>@],
+                   [use the Thread library from boost - it is possible to specify a certain library for the linker
+                        e.g. --with-boost-thread=boost_thread-gcc-mt ]),
+        [
+        if test "$withval" = "no"; then
+			want_boost="no"
+        elif test "$withval" = "yes"; then
+            want_boost="yes"
+            ax_boost_user_thread_lib=""
+        else
+		    want_boost="yes"
+		ax_boost_user_thread_lib="$withval"
+		fi
+        ],
+        [want_boost="yes"]
+	)
+
+	if test "x$want_boost" = "xyes"; then
+        AC_REQUIRE([AC_PROG_CC])
+        AC_REQUIRE([AC_CANONICAL_BUILD])
+		CPPFLAGS_SAVED="$CPPFLAGS"
+		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+		export CPPFLAGS
+
+		LDFLAGS_SAVED="$LDFLAGS"
+		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+		export LDFLAGS
+
+        AC_CACHE_CHECK(whether the Boost::Thread library is available,
+					   ax_cv_boost_thread,
+        [AC_LANG_PUSH([C++])
+			 CXXFLAGS_SAVE=$CXXFLAGS
+
+			 if test "x$host_os" = "xsolaris" ; then
+				 CXXFLAGS="-pthreads $CXXFLAGS"
+			 elif test "x$host_os" = "xmingw32" ; then
+				 CXXFLAGS="-mthreads $CXXFLAGS"
+			 else
+				CXXFLAGS="-pthread $CXXFLAGS"
+			 fi
+			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/thread/thread.hpp>]],
+                                   [[boost::thread_group thrds;
+                                   return 0;]])],
+                   ax_cv_boost_thread=yes, ax_cv_boost_thread=no)
+			 CXXFLAGS=$CXXFLAGS_SAVE
+             AC_LANG_POP([C++])
+		])
+		if test "x$ax_cv_boost_thread" = "xyes"; then
+           if test "x$host_os" = "xsolaris" ; then
+			  BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
+		   elif test "x$host_os" = "xmingw32" ; then
+			  BOOST_CPPFLAGS="-mthreads $BOOST_CPPFLAGS"
+		   else
+			  BOOST_CPPFLAGS="-pthread $BOOST_CPPFLAGS"
+		   fi
+
+			AC_SUBST(BOOST_CPPFLAGS)
+
+			AC_DEFINE(HAVE_BOOST_THREAD,,[define if the Boost::Thread library is available])
+            BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
+
+			LDFLAGS_SAVE=$LDFLAGS
+                        case "x$host_os" in
+                          *bsd* )
+                               LDFLAGS="-pthread $LDFLAGS"
+                          break;
+                          ;;
+                        esac
+            if test "x$ax_boost_user_thread_lib" = "x"; then
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_thread* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'`; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                 [link_thread="no"])
+				done
+                if test "x$link_thread" != "xyes"; then
+                for libextension in `ls -r $BOOSTLIBDIR/boost_thread* 2>/dev/null | sed 's,.*/,,' | sed 's,\..*,,'`; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                 [link_thread="no"])
+				done
+                fi
+
+            else
+               for ax_lib in $ax_boost_user_thread_lib boost_thread-$ax_boost_user_thread_lib; do
+				      AC_CHECK_LIB($ax_lib, exit,
+                                   [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                   [link_thread="no"])
+                  done
+
+            fi
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
+            fi
+			if test "x$link_thread" = "xno"; then
+				AC_MSG_ERROR(Could not link against $ax_lib !)
+                        else
+                           case "x$host_os" in
+                              *bsd* )
+				BOOST_LDFLAGS="-pthread $BOOST_LDFLAGS"
+                              break;
+                              ;;
+                           esac
+
+			fi
+		fi
+
+		CPPFLAGS="$CPPFLAGS_SAVED"
+	LDFLAGS="$LDFLAGS_SAVED"
+	fi
+])

--- a/pam/pam_snapper.c
+++ b/pam/pam_snapper.c
@@ -90,6 +90,11 @@
 #define CDBUS_SIG_CREATE_SNAP_RSP "u"
 #define CDBUS_SIG_STRING_DICT "{ss}"
 
+/*
+ * Constants
+*/
+#define GETPWNAM_R_DEFAULT_BUFFER_SIZE 1024
+
 /**
  * A simple dictionary, ...
  *
@@ -518,6 +523,9 @@ static int get_ugid( pam_handle_t * pamh, const char *pam_user, uid_t * uid, gid
 	struct passwd *result;
 
 	long bufsize = sysconf( _SC_GETPW_R_SIZE_MAX );
+	if (bufsize == -1) {
+		bufsize = GETPWNAM_R_DEFAULT_BUFFER_SIZE;
+	}
 	char buf[bufsize];
 
 	if ( getpwnam_r( pam_user, &pwd, buf, bufsize, &result ) != 0 || result != &pwd ) {

--- a/snapper/AppUtil.cc
+++ b/snapper/AppUtil.cc
@@ -285,6 +285,9 @@ namespace snapper
 	struct passwd* result;
 
 	long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+	if (bufsize == -1) {
+		bufsize = GETPWNAM_R_DEFAULT_BUFFER_SIZE;
+	}
 	char buf[bufsize];
 
 	if (getpwuid_r(uid, &pwd, buf, bufsize, &result) != 0 || result != &pwd)
@@ -306,6 +309,9 @@ namespace snapper
 	struct passwd* result;
 
 	long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+	if (bufsize == -1) {
+		bufsize = GETPWNAM_R_DEFAULT_BUFFER_SIZE;
+	}
 	char buf[bufsize];
 
 	if (getpwnam_r(username, &pwd, buf, bufsize, &result) != 0 || result != &pwd)
@@ -329,6 +335,9 @@ namespace snapper
 	struct group* result;
 
 	long bufsize = sysconf(_SC_GETGR_R_SIZE_MAX);
+	if (bufsize == -1) {
+		bufsize = GETGRNAM_R_DEFAULT_BUFFER_SIZE;
+	}
 	char buf[bufsize];
 
 	if (getgrnam_r(groupname, &grp, buf, bufsize, &result) != 0 || result != &grp)

--- a/snapper/AppUtil.cc
+++ b/snapper/AppUtil.cc
@@ -271,10 +271,10 @@ namespace snapper
     {
 	struct tm s;
 	memset(&s, 0, sizeof(s));
-	const char* p = strptime(str.c_str(), "%F %T", &s);
+	const char* p = strptime(str.c_str(), "%Y-%m-%d %T", &s);
 	if (!p || *p != '\0')
 	    return (time_t)(-1);
-	return utc ? timegm(&s) : timelocal(&s);
+	return utc ? timegm(&s) : mktime(&s);
     }
 
 

--- a/snapper/AppUtil.cc
+++ b/snapper/AppUtil.cc
@@ -209,7 +209,7 @@ namespace snapper
     string
     stringerror(int errnum)
     {
-#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE
+#ifndef HAVE_GNU_STRERROR_R
 	char buf1[100];
 	if (strerror_r(errno, buf1, sizeof(buf1)-1) == 0)
 	    return string(buf1);

--- a/snapper/AppUtil.h
+++ b/snapper/AppUtil.h
@@ -44,6 +44,8 @@ namespace snapper
     using std::map;
     using std::vector;
 
+    const std::size_t GETPWNAM_R_DEFAULT_BUFFER_SIZE = 1024;
+    const std::size_t GETGRNAM_R_DEFAULT_BUFFER_SIZE = 1024;
 
     bool checkDir(const string& Path_Cv);
 

--- a/snapper/AsciiFile.cc
+++ b/snapper/AsciiFile.cc
@@ -211,7 +211,7 @@ AsciiFile::save()
 
 	string line = key + "=\"" + value + "\"";
 
-	Regex rx('^' + Regex::ws + key + '=' + "(['\"]?)([^'\"]*)\\1" + Regex::ws + '$');
+	Regex rx('^' + Regex::ws + key + '=' + "(\"[^'\"]*\"|'[^'\"]*'|[^'\"]*)" + Regex::ws + '$');
 
 	vector<string>::iterator it = find_if(lines(), regex_matches(rx));
 	if (it == lines().end())
@@ -226,12 +226,14 @@ AsciiFile::save()
     bool
     SysconfigFile::getValue(const string& key, string& value) const
     {
-	Regex rx('^' + Regex::ws + key + '=' + "(['\"]?)([^'\"]*)\\1" + Regex::ws + '$');
+	Regex rx('^' + Regex::ws + key + '=' + "(\"[^'\"]*\"|'[^'\"]*'|[^'\"]*)" + Regex::ws + '$');
 
 	if (find_if(lines(), regex_matches(rx)) == lines().end())
 	    return false;
-
-	value = rx.cap(2);
+	value = rx.cap(1);
+	if (!value.empty() && (value.front() == '"' || value.front() == '\'')) {
+	    value = std::string(value.begin() + 1, value.end() - 1);
+	}
 	y2mil("key:" << key << " value:" << value);
 	return true;
     }
@@ -295,12 +297,18 @@ AsciiFile::save()
     {
 	map<string, string> ret;
 
-	Regex rx('^' + Regex::ws + "([0-9A-Z_]+)" + '=' + "(['\"]?)([^'\"]*)\\2" + Regex::ws + '$');
+	Regex rx('^' + Regex::ws + "([0-9A-Z_]+)" + '=' + "(\"[^'\"]*\"|'[^'\"]*'|[^'\"]*)" + Regex::ws + '$');
 
 	for (vector<string>::const_iterator it = Lines_C.begin(); it != Lines_C.end(); ++it)
 	{
 	    if (rx.match(*it))
-		ret[rx.cap(1)] = rx.cap(3);
+	    {
+		string value = rx.cap(2);
+		if (!value.empty() && (value.front() == '"' || value.front() == '\'')) {
+		    value = std::string(value.begin() + 1, value.end() - 1);
+		}
+		ret[rx.cap(1)] = value;
+	    }
 	}
 
 	return ret;

--- a/snapper/FileUtils.h
+++ b/snapper/FileUtils.h
@@ -28,7 +28,7 @@
 #include <vector>
 #include <functional>
 #include <boost/thread.hpp>
-
+#include <sys/types.h>
 
 namespace snapper
 {

--- a/snapper/Logger.cc
+++ b/snapper/Logger.cc
@@ -146,6 +146,9 @@ namespace snapper
 	    struct passwd* result;
 
 	    long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+	    if (bufsize == -1) {
+		bufsize = GETPWNAM_R_DEFAULT_BUFFER_SIZE;
+	    }
 	    char buf[bufsize];
 
 	    if (getpwuid_r(geteuid(), &pwd, buf, bufsize, &result) == 0 && result == &pwd)

--- a/snapper/Makefile.am
+++ b/snapper/Makefile.am
@@ -2,7 +2,7 @@
 # Makefile.am for snapper/snapper
 #
 
-AM_CXXFLAGS = -D_FILE_OFFSET_BITS=64
+AM_CXXFLAGS = -D_FILE_OFFSET_BITS=64 @BOOST_CPPFLAGS@
 
 AM_CPPFLAGS = -I/usr/include/libxml2
 
@@ -56,8 +56,8 @@ libsnapper_la_SOURCES +=				\
 	MntTable.cc		MntTable.h
 endif
 
-libsnapper_la_LDFLAGS = -version-info @LIBVERSION_INFO@
-libsnapper_la_LIBADD = -lboost_thread -lboost_system -lxml2 -lacl -lz -lm
+libsnapper_la_LDFLAGS = -version-info @LIBVERSION_INFO@ @BOOST_LDFLAGS@
+libsnapper_la_LIBADD = @BOOST_THREAD_LIB@ @BOOST_SYSTEM_LIB@ -lxml2 -lacl -lz -lm
 if ENABLE_ROLLBACK
 libsnapper_la_LIBADD += -lmount
 endif

--- a/snapper/Makefile.am
+++ b/snapper/Makefile.am
@@ -57,7 +57,7 @@ libsnapper_la_SOURCES +=				\
 endif
 
 libsnapper_la_LDFLAGS = -version-info @LIBVERSION_INFO@ @BOOST_LDFLAGS@
-libsnapper_la_LIBADD = @BOOST_THREAD_LIB@ @BOOST_SYSTEM_LIB@ -lxml2 -lacl -lz -lm
+libsnapper_la_LIBADD = @BOOST_THREAD_LIB@ @BOOST_SYSTEM_LIB@ @LTLIBINTL@ -lxml2 -lacl -lz -lm
 if ENABLE_ROLLBACK
 libsnapper_la_LIBADD += -lmount
 endif

--- a/snapper/Snapshot.h
+++ b/snapper/Snapshot.h
@@ -29,6 +29,8 @@
 #include <list>
 #include <map>
 
+#include <sys/types.h>
+
 #include "snapper/Exception.h"
 
 

--- a/snapper/SystemCmd.h
+++ b/snapper/SystemCmd.h
@@ -23,7 +23,7 @@
 #ifndef SNAPPER_SYSTEM_CMD_H
 #define SNAPPER_SYSTEM_CMD_H
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <stdio.h>
 
 #include <string>

--- a/snapper/SystemCmd.h
+++ b/snapper/SystemCmd.h
@@ -31,6 +31,9 @@
 #include <list>
 #include <boost/noncopyable.hpp>
 
+// These macro definitions collide with SystemCmd::(stdin|stderr)(...)
+#undef stderr
+#undef stdout
 
 namespace snapper
 {


### PR DESCRIPTION
While packaging snapper for [Alpine Linux](http://alpinelinux.org/) which uses [musl](http://www.musl-libc.org/) as its libc implementation I encountered some portability issues. This patch series enables successful deployment of snapper on targets using musl libc.
