### PR TITLE
Fix dbus interface methods types.

### DIFF
--- a/doc/dbus-protocol.txt
+++ b/doc/dbus-protocol.txt
@@ -35,9 +35,9 @@ signal SnapshotCreated config-name number
 signal SnapshotModified config-name number
 signal SnapshotsDeleted config-name list(numbers)
 
-method MountSnapshot config-name number user-request
+method MountSnapshot config-name number user-request -> path
 method UmountSnapshot config-name number user-request
-method GetMountPoint config-name number
+method GetMountPoint config-name number -> path
 
 Snapshots mounted with user-request set to false will be unmounted (delayed)
 after the client disconnects.
@@ -45,7 +45,7 @@ after the client disconnects.
 method Sync config-name
 
 
-method CreateComparison config-name number1 number2
+method CreateComparison config-name number1 number2 -> num-files
 method DeleteComparison config-name number1 number2
 
 The following command require a successful CreateComparison in advance.

--- a/server/Client.cc
+++ b/server/Client.cc
@@ -203,7 +203,7 @@ Client::introspect(DBus::Connection& conn, DBus::Message& msg)
 	"    </signal>\n"
 
 	"    <method name='ListConfigs'>\n"
-	"      <arg name='configs' type='v' direction='out'/>\n"
+	"      <arg name='configs' type='a(ssa{ss})' direction='out'/>\n"
 	"    </method>\n"
 
 	"    <method name='GetConfig'>\n"
@@ -237,14 +237,14 @@ Client::introspect(DBus::Connection& conn, DBus::Message& msg)
 
 	"    <method name='ListSnapshots'>\n"
 	"      <arg name='config-name' type='s' direction='in'/>\n"
-	"      <arg name='snapshots' type='v' direction='out'/>\n"
+	"      <arg name='snapshots' type='a(uquxussa{ss})' direction='out'/>\n"
 	"    </method>\n"
 
 	"    <method name='ListSnapshotsAtTime'>\n"
 	"      <arg name='config-name' type='s' direction='in'/>\n"
 	"      <arg name='begin' type='x' direction='in'/>\n"
 	"      <arg name='end' type='x' direction='in'/>\n"
-	"      <arg name='snapshots' type='v' direction='out'/>\n"
+	"      <arg name='snapshots' type='a(uquxussa{ss})' direction='out'/>\n"
 	"    </method>\n"
 
 	"    <method name='GetSnapshot'>\n"
@@ -314,6 +314,7 @@ Client::introspect(DBus::Connection& conn, DBus::Message& msg)
 	"      <arg name='config-name' type='s' direction='in'/>\n"
 	"      <arg name='number' type='u' direction='in'/>\n"
 	"      <arg name='user-request' type='b' direction='in'/>\n"
+	"      <arg name='path' type='s' direction='out'/>\n"
 	"    </method>\n"
 
 	"    <method name='UmountSnapshot'>\n"
@@ -325,6 +326,7 @@ Client::introspect(DBus::Connection& conn, DBus::Message& msg)
 	"    <method name='GetMountPoint'>\n"
 	"      <arg name='config-name' type='s' direction='in'/>\n"
 	"      <arg name='number' type='u' direction='in'/>\n"
+	"      <arg name='path' type='s' direction='out'/>\n"
 	"    </method>\n"
 
 	"    <method name='CreateComparison'>\n"
@@ -344,7 +346,7 @@ Client::introspect(DBus::Connection& conn, DBus::Message& msg)
 	"      <arg name='config-name' type='s' direction='in'/>\n"
 	"      <arg name='number1' type='u' direction='in'/>\n"
 	"      <arg name='number2' type='u' direction='in'/>\n"
-	"      <arg name='files' type='v' direction='out'/>\n"
+	"      <arg name='files' type='a(su)' direction='out'/>\n"
 	"    </method>\n"
 
 	"    <method name='Sync'>\n"
@@ -1224,6 +1226,10 @@ Client::create_comparison(DBus::Connection& conn, DBus::Message& msg)
     it->inc_use_count();
 
     DBus::MessageMethodReturn reply(msg);
+
+    DBus::Hoho hoho(reply);
+    dbus_uint32_t num_files = comparison->getFiles().size();
+    hoho << num_files;
 
     conn.send(reply);
 }


### PR DESCRIPTION
The XML in Introspect method doesn't contain correct information about a few methods.

- ListConfigs, ListSnapshots, ListSnapshotsAtTime, GetFiles don't return variadic but raw value (not packed inside variadic).
- MountSnapshot, GetMountPoint didn't contain information about return type.
- CreateComparison declared that it returns num of files but implementation didn't return anything.

I tried to add a unit/real test that will validate the interface types but I couldn't mock objects that Client class is using and I can't run snapperd without interfring with snapper currently installed in the system.

I was testing in sandboxed installation using this scripts: https://gist.github.com/p2004a/9762b22c3edeb0f5d18a (pydbus library validates the return types etc.)