### PR TITLE
Improved handling of dbus disconnection

### DIFF
--- a/dbus/DBusConnection.cc
+++ b/dbus/DBusConnection.cc
@@ -41,6 +41,7 @@ namespace DBus
 	    dbus_error_free(&err);
 	    throw FatalException();
 	}
+	dbus_connection_set_exit_on_disconnect(conn, false);
 
 	if (!conn)
 	{
@@ -146,7 +147,14 @@ namespace DBus
     Connection::pop_message()
     {
 	boost::lock_guard<boost::mutex> lock(mutex);
-	return dbus_connection_pop_message(conn);
+	DBusMessage* tmp = dbus_connection_pop_message(conn);
+	if (tmp &&
+	    strcmp(dbus_message_get_interface(tmp), DBUS_INTERFACE_LOCAL) == 0 &&
+	    strcmp(dbus_message_get_member(tmp), "Disconnected") == 0)
+	{
+	    throw FatalException();
+	}
+	return tmp;
     }
 
 


### PR DESCRIPTION
Related to #176. I was thinking about more clear way of doing it but it looks like every other method is just throwing FatalException when something unexpected happens so I implemented this in the same way.
