### PR TITLE
rule out race while (u)mounting lvm snapshot

### DIFF
--- a/snapper/Lvm.cc
+++ b/snapper/Lvm.cc
@@ -251,6 +251,8 @@ namespace snapper
     void
     Lvm::mountSnapshot(unsigned int num) const
     {
+	boost::unique_lock<boost::mutex> lock(mount_mutex);
+
 	if (isSnapshotMounted(num))
 	    return;
 
@@ -273,6 +275,8 @@ namespace snapper
     void
     Lvm::umountSnapshot(unsigned int num) const
     {
+	boost::unique_lock<boost::mutex> lock(mount_mutex);
+
 	if (isSnapshotMounted(num))
 	{
 	    SDir info_dir = openInfoDir(num);

--- a/snapper/Lvm.h
+++ b/snapper/Lvm.h
@@ -24,6 +24,7 @@
 #define SNAPPER_LVM_H
 
 #include <boost/noncopyable.hpp>
+#include <boost/thread/mutex.hpp>
 
 #include "snapper/Filesystem.h"
 
@@ -107,6 +108,8 @@ namespace snapper
 	virtual bool checkSnapshot(unsigned int num) const;
 
     private:
+
+	mutable boost::mutex mount_mutex;
 
 	const string mount_type;
 	const LvmCapabilities* caps;


### PR DESCRIPTION
Hi Arvin, snapper maintainers,

this commit fixes a race in snapperd daemon while trying to (u)mount an lvm snapshot from more than one thread. To reproduce it just run following snapper commands close to each other on lvm backend.

snapper create -t post --pre-num 1 (with background comparison enabled, let's say post snapshot will be 2)
and immediately after it:
snapper status 1..2

The clash is between Background worker and create_comparison thread originating in snapper status cmd.