### PR TITLE
Implement basic SELinux support for snapper

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,16 @@ AC_ARG_ENABLE([pam], AC_HELP_STRING([--disable-pam],[Disable pam plugin support]
                 [with_pam=$enableval],[with_pam=yes])
 AM_CONDITIONAL(HAVE_PAM, [test "x$with_pam" = "xyes"])
 
+AC_ARG_ENABLE([selinux], AC_HELP_STRING([--enable-selinux],[Enable support for SELinux LSM]),
+		[with_selinux=$enableval],[with_selinux=no])
+AM_CONDITIONAL(ENABLE_SELINUX, [test "x$enable_selinux" = "xyes"])
+
+if test "x$with_selinux" = "xyes"; then
+	AC_DEFINE(ENABLE_SELINUX, 1, [Enable SELinux support])
+	AC_CHECK_HEADER(selinux/selinux.h,[],[AC_MSG_ERROR([Cannot find libselinux headers. Please install libselinux-devel])])
+	AC_CHECK_LIB(selinux, selinux_snapperd_contexts_path, [], [AC_MSG_ERROR([selinux library does not provide selinux_snapperd_contexts_path symbol])])
+fi
+
 PKG_CHECK_MODULES(DBUS, dbus-1)
 
 AC_CHECK_HEADER(acl/libacl.h,[],[AC_MSG_ERROR([Cannout find libacl headers. Please install libacl-devel])])

--- a/snapper/Btrfs.cc
+++ b/snapper/Btrfs.cc
@@ -58,6 +58,9 @@
 #ifdef ENABLE_ROLLBACK
 #include "snapper/MntTable.h"
 #endif
+#ifdef ENABLE_SELINUX
+#include "snapper/Selinux.h"
+#endif
 
 
 namespace snapper
@@ -133,6 +136,19 @@ namespace snapper
 	}
 
 	SFile x(subvolume_dir, ".snapshots");
+#ifdef ENABLE_SELINUX
+	try
+	{
+	    SnapperContexts scontexts;
+
+	    x.fsetfilecon(scontexts.subvolume_context());
+	}
+	catch (const SelinuxException& e)
+	{
+	    SN_CAUGHT(e);
+	    // fall through intentional
+	}
+#endif
 	struct stat stat;
 	if (x.stat(&stat, 0) == 0)
 	    x.chmod(stat.st_mode & ~0027, 0);

--- a/snapper/FileUtils.h
+++ b/snapper/FileUtils.h
@@ -42,6 +42,7 @@ namespace snapper
 	XA_SUPPORTED
     };
 
+    class SelinuxLabelHandle;
 
     /*
      * The member functions of SDir and SFile are secure (avoid race
@@ -101,6 +102,11 @@ namespace snapper
 		   const string& mount_data) const;
 	bool umount(const string& mount_point) const;
 
+	bool fsetfilecon(const string& name, char* con) const;
+	bool fsetfilecon(char* con) const;
+	bool restorecon(SelinuxLabelHandle* sh) const;
+	bool restorecon(const string& name, SelinuxLabelHandle* sh) const;
+
     private:
 
 	XaAttrsStatus xastatus;
@@ -133,6 +139,9 @@ namespace snapper
 
 	ssize_t listxattr(char* list, size_t size) const;
 	ssize_t getxattr(const char* name, void* value, size_t size) const;
+
+	void fsetfilecon(char* con) const;
+	void restorecon(SelinuxLabelHandle* sh) const;
 
     private:
 

--- a/snapper/Lvm.h
+++ b/snapper/Lvm.h
@@ -74,6 +74,7 @@ namespace snapper
 	bool time_support;
     };
 
+    class SelinuxLabelHandle;
 
     class Lvm : public Filesystem
     {
@@ -114,11 +115,13 @@ namespace snapper
 	const string mount_type;
 	const LvmCapabilities* caps;
 	LvmCache* cache;
+	SelinuxLabelHandle* sh;
 
 	bool detectThinVolumeNames(const MtabData& mtab_data);
 	void activateSnapshot(const string& vg_name, const string& lv_name) const;
 	void deactivateSnapshot(const string& vg_name, const string& lv_name) const;
 	bool detectInactiveSnapshot(const string& vg_name, const string& lv_name) const;
+	void createLvmConfig(const SDir& subvolume_dir, int mode) const;
 
 	string getDevice(unsigned int num) const;
 

--- a/snapper/Makefile.am
+++ b/snapper/Makefile.am
@@ -56,6 +56,11 @@ libsnapper_la_SOURCES +=				\
 	MntTable.cc		MntTable.h
 endif
 
+if ENABLE_SELINUX
+libsnapper_la_SOURCES +=				\
+	Selinux.cc		Selinux.h
+endif
+
 libsnapper_la_LDFLAGS = -version-info @LIBVERSION_INFO@
 libsnapper_la_LIBADD = -lboost_thread -lboost_system -lxml2 -lacl -lz -lm
 if ENABLE_ROLLBACK

--- a/snapper/Selinux.cc
+++ b/snapper/Selinux.cc
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) [2016] Red Hat, Inc.
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact Novell, Inc.
+ *
+ * To contact Novell about this file by physical or electronic mail, you may
+ * find current contact information at www.novell.com.
+ */
+
+#include <cerrno>
+#include <map>
+
+#include <boost/algorithm/string.hpp>
+
+#include "snapper/AppUtil.h"
+#include "snapper/AsciiFile.h"
+#include "snapper/Log.h"
+#include "snapper/Selinux.h"
+
+namespace snapper
+{
+
+    SnapperContexts::SnapperContexts()
+	: subvolume_ctx(NULL)
+    {
+	std::map<string,string> snapperd_contexts;
+
+	try
+	{
+	    AsciiFileReader asciifile(selinux_snapperd_contexts_path());
+
+	    string line;
+	    while (asciifile.getline(line))
+	    {
+		// commented line
+		if (line[0] == '#')
+		    continue;
+
+		// do not parse lines w/o '=' symbol
+		string::size_type pos = line.find('=');
+		if (pos == string::npos)
+		    continue;
+
+		if (!snapperd_contexts.insert(make_pair(boost::trim_copy(line.substr(0, pos)), boost::trim_copy(line.substr(pos + 1)))).second)
+		{
+		    SN_THROW(SelinuxException("Duplicate key in contexts file"));
+		}
+	    }
+	}
+	catch (const FileNotFoundException& e)
+	{
+	    SN_CAUGHT(e);
+	    SN_THROW(SelinuxException("Failed to parse contexts file"));
+	}
+
+	std::map<string,string>::const_iterator cit = snapperd_contexts.find(selinux_snapperd_data);
+	if (cit == snapperd_contexts.end())
+	{
+	    SN_THROW(SelinuxException("Snapperd data context not found"));
+	}
+
+	subvolume_ctx = context_new(cit->second.c_str());
+	if (!subvolume_ctx)
+	{
+	    SN_THROW(SelinuxException());
+	}
+    }
+
+
+    DefaultSelinuxFileContext::DefaultSelinuxFileContext(char* context)
+    {
+	if (setfscreatecon(context) < 0)
+	{
+	    SN_THROW(SelinuxException(string("setfscreatecon(") + context + ") failed"));
+	}
+    }
+
+
+    DefaultSelinuxFileContext::~DefaultSelinuxFileContext()
+    {
+	if (setfscreatecon(NULL))
+	    y2err("Failed to reset default file system objects context");
+    }
+
+
+    SelinuxLabelHandle::SelinuxLabelHandle()
+	: handle(selabel_open(SELABEL_CTX_FILE, NULL, 0))
+    {
+	if (!handle)
+	{
+	    SN_THROW(SelinuxException("Failed to open SELinux labeling handle: " + stringerror(errno)));
+	}
+    }
+
+
+    char*
+    SelinuxLabelHandle::selabel_lookup(const string& path, int mode)
+    {
+	char *con;
+
+	if (!::selabel_lookup(handle, &con, path.c_str(), mode))
+	{
+	    y2deb("found label for path " << path << ": " << con);
+	    return con;
+	}
+	else
+	{
+	    if (errno == ENOENT)
+		y2deb("Selinux context not defined for path " << path);
+
+	    return NULL;
+	}
+    }
+
+
+    int
+    _is_selinux_enabled()
+    {
+	static int selinux_checked = 0, selinux_enabled = 0;
+
+	if (!selinux_checked)
+	{
+	    selinux_enabled = is_selinux_enabled();
+	    selinux_checked = 1;
+	    y2mil("Selinux support " << (selinux_enabled ? "en" : "dis") << "abled");
+	}
+
+	return selinux_enabled;
+    }
+
+
+    SelinuxLabelHandle*
+    SelinuxLabelHandle::get_selinux_handle()
+    {
+	if (_is_selinux_enabled())
+	{
+	    static SelinuxLabelHandle handle;
+	    return &handle;
+	}
+
+	return NULL;
+    }
+
+}

--- a/snapper/Selinux.cc
+++ b/snapper/Selinux.cc
@@ -125,15 +125,15 @@ namespace snapper
     }
 
 
-    int
+    bool
     _is_selinux_enabled()
     {
-	static int selinux_checked = 0, selinux_enabled = 0;
+	static bool selinux_enabled, selinux_checked = false;
 
 	if (!selinux_checked)
 	{
-	    selinux_enabled = is_selinux_enabled();
-	    selinux_checked = 1;
+	    selinux_enabled = (is_selinux_enabled() == 1); // may return -1 on error
+	    selinux_checked = true;
 	    y2mil("Selinux support " << (selinux_enabled ? "en" : "dis") << "abled");
 	}
 

--- a/snapper/Selinux.h
+++ b/snapper/Selinux.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) [2016] Red Hat, Inc.
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact Novell, Inc.
+ *
+ * To contact Novell about this file by physical or electronic mail, you may
+ * find current contact information at www.novell.com.
+ */
+
+
+#ifndef SNAPPER_SELINUX_H
+#define SNAPPER_SELINUX_H
+
+#include <string>
+#include <selinux/context.h>
+#include <selinux/label.h>
+#include <selinux/selinux.h>
+
+#include <boost/noncopyable.hpp>
+
+#include "snapper/Exception.h"
+
+
+namespace snapper {
+
+    struct SelinuxException : public Exception
+    {
+	explicit SelinuxException() : Exception("SELinux error") {}
+	explicit SelinuxException(const std::string& msg) : Exception(msg) {}
+    };
+
+    using std::string;
+
+    const static string selinux_snapperd_data = "snapperd_data";
+
+    int _is_selinux_enabled();
+
+    class SnapperContexts
+    {
+    public:
+	char* subvolume_context() const { return context_str(subvolume_ctx); }
+	SnapperContexts();
+	~SnapperContexts() { context_free(subvolume_ctx); }
+    private:
+	context_t subvolume_ctx;
+    };
+
+    class DefaultSelinuxFileContext : private boost::noncopyable
+    {
+    public:
+	DefaultSelinuxFileContext(char* context);
+	~DefaultSelinuxFileContext();
+    };
+
+
+    class SelinuxLabelHandle : public boost::noncopyable
+    {
+    public:
+	static SelinuxLabelHandle* get_selinux_handle();
+
+	char* selabel_lookup(const string& path, int mode);
+
+	~SelinuxLabelHandle() { selabel_close(handle); }
+    private:
+	SelinuxLabelHandle();
+
+	struct selabel_handle* handle;
+    };
+
+}
+
+#endif

--- a/snapper/Selinux.h
+++ b/snapper/Selinux.h
@@ -45,7 +45,7 @@ namespace snapper {
 
     const static string selinux_snapperd_data = "snapperd_data";
 
-    int _is_selinux_enabled();
+    bool _is_selinux_enabled();
 
     class SnapperContexts
     {

--- a/snapper/Snapper.h
+++ b/snapper/Snapper.h
@@ -39,6 +39,7 @@ namespace snapper
 
     class Filesystem;
     class SDir;
+    class SelinuxLabelHandle;
 
 
     class ConfigInfo : public SysconfigFile
@@ -176,6 +177,10 @@ namespace snapper
 
 	void syncAcl(const vector<uid_t>& uids, const vector<gid_t>& gids) const;
 
+	void syncSelinuxContexts() const;
+	void syncSelinuxContextsInInfosDir() const;
+	void syncInfoDir(SDir& dir) const;
+
 	ConfigInfo* config_info;
 
 	Filesystem* filesystem;
@@ -183,6 +188,8 @@ namespace snapper
 	vector<string> ignore_patterns;
 
 	Snapshots snapshots;
+
+	SelinuxLabelHandle* selabel_handle;
 
     };
 

--- a/snapper/Snapper.h
+++ b/snapper/Snapper.h
@@ -177,8 +177,8 @@ namespace snapper
 
 	void syncAcl(const vector<uid_t>& uids, const vector<gid_t>& gids) const;
 
-	void syncSelinuxContexts() const;
-	void syncSelinuxContextsInInfosDir() const;
+	void syncSelinuxContexts(bool skip_snapshot_dir) const;
+	void syncSelinuxContextsInInfosDir(bool skip_snapshot_dir) const;
 	void syncInfoDir(SDir& dir) const;
 
 	ConfigInfo* config_info;


### PR DESCRIPTION
Hi  Arvin,

this pull request is supposed to fix some long standing issues with snapper and SELinux in SELinux enabled distributions.

There're multiple issues with snapper and SELinux.

1) Kernel ioctl call is not able to set proper selinux context on btrfs subvolume (Btrfs::createConfig() routine). No matter where .snapshots subvolume was created by snapperd, it always ended with unlabeled_t type even if selinux policy had defined default type for well-know path (i.e.: /.snapshots or /var/.snapshots, /home/user/.snapshots, ...). Due to 'unlabeled_t' type any following file creation operation (open(), mkdir()...) inside .snapshots subvolume also set wrong context on any snapper metadata (info.xml, filelist-*.txt). Effectively this forced  us to run snapperd in domain pretty much similar to unconfined one (free to do almost anything) which is not so comfortable with regard to MAC definiton.

2) With Lvm backend it was not so bad as createConfig() calls ordinary mkdir() to create .snapshots directory. It worked unless user decided to mount his own filesystem in arbitrary mount directory instead of in on some well-know path (/mnt/test_dir, /var...). Due to it I enforce setfscreatecon() in Lvm backend to ensure the resulting directory .snapshots will have proper selinux context set after the syscall. Otherwise we'd end with pretty much same flawed setup as with btrfs one.

3) In Snapper I try to sync all snapper metadata before continuing further so that existing snapper configurations can run after we enable selinux support with proper (confined) policy

Let me know If you want me to add anything to the pull request (verbose documentation?) The current code won't compile because it has dependancy on not yet merged libselinux API. The workaround is in my devel-branch dev-selinux: https://github.com/oniko/ok-snap/commit/e8e15f335d48fd990b8868ad6d6e4774c29f20ac
