### PR TITLE
[FR] some API extensions

### DIFF
--- a/snapper/Btrfs.cc
+++ b/snapper/Btrfs.cc
@@ -1451,6 +1451,29 @@ namespace snapper
 	}
     }
 
+
+    bool
+    Btrfs::isActive(unsigned int num) const
+    {
+	bool ret = false;
+
+	try
+	{
+	    if (num == 0)
+		SN_THROW(IllegalSnapshotException());
+
+	    SDir snapshot_dir = openSnapshotDir(num);
+	    SDir subvolume_dir = openSubvolumeDir();
+	    ret = get_id(snapshot_dir.fd()) == get_id(subvolume_dir.fd());
+	}
+	catch (const runtime_error& e)
+	{
+	    SN_THROW(IOErrorException(string("get active failed, ") + e.what()));
+	}
+
+	return ret;
+    }
+
 #else
 
     bool
@@ -1462,6 +1485,13 @@ namespace snapper
 
     void
     Btrfs::setDefault(unsigned int num) const
+    {
+	throw std::logic_error("not implemented");
+    }
+
+
+    bool
+    Btrfs::isActive(unsigned int num) const
     {
 	throw std::logic_error("not implemented");
     }

--- a/snapper/Btrfs.cc
+++ b/snapper/Btrfs.cc
@@ -1398,6 +1398,33 @@ namespace snapper
 
 #ifdef ENABLE_ROLLBACK
 
+    bool
+    Btrfs::isDefault(unsigned int num) const
+    {
+	bool ret = false;
+
+	try
+	{
+	    SDir subvolume_dir = openSubvolumeDir();
+	    subvolid_t id = get_default_id(subvolume_dir.fd());
+	    if (num == 0)
+	    {
+		ret = get_id(subvolume_dir.fd()) == id;
+	    }
+	    else
+	    {
+		ret = get_id(openSnapshotDir(num).fd()) == id;
+	    }
+	}
+	catch (const runtime_error& e)
+	{
+	    SN_THROW(IOErrorException(string("get default failed, ") + e.what()));
+	}
+
+	return ret;
+    }
+
+
     void
     Btrfs::setDefault(unsigned int num) const
     {
@@ -1425,6 +1452,13 @@ namespace snapper
     }
 
 #else
+
+    bool
+    Btrfs::isDefault(unsigned int num) const
+    {
+	throw std::logic_error("not implemented");
+    }
+
 
     void
     Btrfs::setDefault(unsigned int num) const

--- a/snapper/Btrfs.h
+++ b/snapper/Btrfs.h
@@ -78,6 +78,8 @@ namespace snapper
 	virtual bool isDefault(unsigned int num) const;
 	virtual void setDefault(unsigned int num) const;
 
+	virtual bool isActive(unsigned int num) const;
+
 	virtual void sync() const;
 
 	virtual qgroup_t getQGroup() const { return qgroup; }

--- a/snapper/Btrfs.h
+++ b/snapper/Btrfs.h
@@ -75,6 +75,7 @@ namespace snapper
 
 	virtual void cmpDirs(const SDir& dir1, const SDir& dir2, cmpdirs_cb_t cb) const;
 
+	virtual bool isDefault(unsigned int num) const;
 	virtual void setDefault(unsigned int num) const;
 
 	virtual void sync() const;

--- a/snapper/Filesystem.cc
+++ b/snapper/Filesystem.cc
@@ -184,6 +184,13 @@ namespace snapper
     }
 
 
+    bool
+    Filesystem::isActive(unsigned int num) const
+    {
+	throw std::logic_error("not implemented");
+    }
+
+
     void
     Filesystem::sync() const
     {

--- a/snapper/Filesystem.cc
+++ b/snapper/Filesystem.cc
@@ -170,6 +170,13 @@ namespace snapper
     }
 
 
+    bool
+    Filesystem::isDefault(unsigned int num) const
+    {
+	throw std::logic_error("not implemented");
+    }
+
+
     void
     Filesystem::setDefault(unsigned int num) const
     {

--- a/snapper/Filesystem.h
+++ b/snapper/Filesystem.h
@@ -85,6 +85,8 @@ namespace snapper
 	virtual bool isDefault(unsigned int num) const;
 	virtual void setDefault(unsigned int num) const;
 
+	virtual bool isActive(unsigned int num) const;
+
 	virtual void sync() const;
 
     protected:

--- a/snapper/Filesystem.h
+++ b/snapper/Filesystem.h
@@ -82,6 +82,7 @@ namespace snapper
 
 	virtual void cmpDirs(const SDir& dir1, const SDir& dir2, cmpdirs_cb_t cb) const;
 
+	virtual bool isDefault(unsigned int num) const;
 	virtual void setDefault(unsigned int num) const;
 
 	virtual void sync() const;

--- a/snapper/Snapshot.cc
+++ b/snapper/Snapshot.cc
@@ -134,6 +134,13 @@ namespace snapper
 
 
     void
+    Snapshot::setDefault() const
+    {
+	return snapper->getFilesystem()->setDefault(num);
+    }
+
+
+    void
     Snapshots::read()
     {
 	Regex rx("^[0-9]+$");

--- a/snapper/Snapshot.cc
+++ b/snapper/Snapshot.cc
@@ -147,6 +147,13 @@ namespace snapper
     }
 
 
+    bool
+    Snapshot::isActive() const
+    {
+	return !isCurrent() && snapper->getFilesystem()->isActive(num);
+    }
+
+
     void
     Snapshots::read()
     {

--- a/snapper/Snapshot.cc
+++ b/snapper/Snapshot.cc
@@ -133,6 +133,13 @@ namespace snapper
     }
 
 
+    bool
+    Snapshot::isDefault() const
+    {
+	return snapper->getFilesystem()->isDefault(num);
+    }
+
+
     void
     Snapshot::setDefault() const
     {

--- a/snapper/Snapshot.h
+++ b/snapper/Snapshot.h
@@ -107,6 +107,8 @@ namespace snapper
 	bool isDefault() const;
 	void setDefault() const;
 
+	bool isActive() const;
+
 	void mountFilesystemSnapshot(bool user_request) const;
 	void umountFilesystemSnapshot(bool user_request) const;
 	void handleUmountFilesystemSnapshot() const;

--- a/snapper/Snapshot.h
+++ b/snapper/Snapshot.h
@@ -104,6 +104,8 @@ namespace snapper
 
 	bool isReadOnly() const;
 
+	void setDefault() const;
+
 	void mountFilesystemSnapshot(bool user_request) const;
 	void umountFilesystemSnapshot(bool user_request) const;
 	void handleUmountFilesystemSnapshot() const;

--- a/snapper/Snapshot.h
+++ b/snapper/Snapshot.h
@@ -104,6 +104,7 @@ namespace snapper
 
 	bool isReadOnly() const;
 
+	bool isDefault() const;
 	void setDefault() const;
 
 	void mountFilesystemSnapshot(bool user_request) const;


### PR DESCRIPTION
For some my local project I need an utility using Snapper API. But for this purpose I needed to expand API.

These changes allow:
- change default snapshot (will be activated on next boot time)
- determine snapshot is default (will be activated on next boot time)
- determine snapshot is active (activated on last boot time)

These changes don't modify behavior of other components.