### PR TITLE
Add boost linker flags to fix compilation under u16.04

### DIFF
--- a/examples/c++-lib/Makefile.am
+++ b/examples/c++-lib/Makefile.am
@@ -5,6 +5,7 @@
 AM_CPPFLAGS = -I$(top_srcdir)
 
 LDADD = ../../snapper/libsnapper.la
+AM_LDFLAGS = -lboost_system
 
 noinst_PROGRAMS = List ListAll Create CmpDirs CreateNumber CreateTimeline
 

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -14,4 +14,4 @@ snapperd_SOURCES =					\
 	Types.cc		Types.h
 
 snapperd_LDADD = ../snapper/libsnapper.la ../dbus/libdbus.la -lrt
-
+snapperd_LDFLAGS = -lboost_system -lboost_thread

--- a/testsuite-cmp/Makefile.am
+++ b/testsuite-cmp/Makefile.am
@@ -3,6 +3,7 @@
 #
 
 AM_CPPFLAGS = -I$(top_srcdir)
+AM_LDFLAGS = -lboost_system
 
 LDADD = ../snapper/libsnapper.la
 


### PR DESCRIPTION
Adding the correct linker flags for -lboost_system -lboost_thread enabled me to compile it under ubuntu 16.04.