### PR TITLE
properly add selinux-readme file to distribution pkg

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -27,11 +27,8 @@ html: $(man_MANS:%.5=%.html) $(man_MANS:%.8=%.html)
 .xml.html: .xml
 	$(XSLTPROC) --nonet html.xsl $< > $@
 
-EXTRA_DIST = dbus-protocol.txt manpages.xsl html.xsl
+EXTRA_DIST = dbus-protocol.txt manpages.xsl html.xsl selinux-readme.txt
 
-if ENABLE_SELINUX
-EXTRA_DIST += selinux-readme.txt
-endif
 
 clean-local:
 	rm -f *.{5,8} *.html


### PR DESCRIPTION
Hi Arvin,

fixing my last commit. First, the readme file should be added to distribution package unconditionally, second the 'condition' didn't work at all... sigh