### PR TITLE
fix objects termination clashes on shutdown

### DIFF
--- a/server/Background.cc
+++ b/server/Background.cc
@@ -31,9 +31,6 @@
 #include "Background.h"
 
 
-Backgrounds backgrounds;
-
-
 Backgrounds::Backgrounds()
 {
 }

--- a/server/Background.h
+++ b/server/Background.h
@@ -75,7 +75,4 @@ private:
 };
 
 
-extern Backgrounds backgrounds;
-
-
 #endif

--- a/server/Client.h
+++ b/server/Client.h
@@ -51,6 +51,9 @@ using namespace snapper;
 
 extern boost::shared_mutex big_mutex;
 
+class Backgrounds;
+class Clients;
+
 
 struct NoComparison : Exception
 {
@@ -112,7 +115,7 @@ public:
 
     void dispatch(DBus::Connection& conn, DBus::Message& msg);
 
-    Client(const string& name);
+    Client(const string& name, const Clients& clients);
     ~Client();
 
     list<Comparison*>::iterator find_comparison(Snapper* snapper, unsigned int number1,
@@ -160,12 +163,15 @@ private:
 
     void worker();
 
+    const Clients& clients;
+
 };
 
 
 class Clients
 {
 public:
+    Clients(Backgrounds& backgrounds);
 
     typedef list<Client>::iterator iterator;
     typedef list<Client>::const_iterator const_iterator;
@@ -185,14 +191,15 @@ public:
 
     bool has_zombies() const;
 
+    Backgrounds& backgrounds() const;
+
 private:
 
     list<Client> entries;
 
+    Backgrounds& bgs;
+
 };
-
-
-extern Clients clients;
 
 
 #endif

--- a/server/snapperd.cc
+++ b/server/snapperd.cc
@@ -57,11 +57,16 @@ public:
     void periodic();
     milliseconds periodic_timeout();
 
+private:
+
+    Backgrounds backgrounds;
+    Clients clients;
+
 };
 
 
 MyMainLoop::MyMainLoop(DBusBusType type)
-    : MainLoop(type)
+    : MainLoop(type), backgrounds(), clients(backgrounds)
 {
 }
 


### PR DESCRIPTION
This is one of possible fixes for issue #256. My goal is to make it clear in what order objects used solely in snapperd server are torn down.

Of course the minimalistic fix is to remove y2deb() message from Backgrounds worker invoked on snapperd shutdown.

Regards O.