### PR TITLE
Added boot service

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -5,7 +5,7 @@
 EXTRA_DIST = sysconfig.snapper base.txt lvm.txt x11.txt snapper.logrotate	\
 	default-config org.opensuse.Snapper.conf org.opensuse.Snapper.service	\
 	zypp-plugin.conf timeline.service timeline.timer cleanup.service	\
-	cleanup.timer
+	cleanup.timer boot.service boot.timer
 
 install-data-local:
 	install -D -m 644 snapper.logrotate $(DESTDIR)/etc/logrotate.d/snapper

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -25,8 +25,9 @@ install-data-local:
 	install -D -m 644 timeline.timer $(DESTDIR)/usr/lib/systemd/system/snapper-timeline.timer
 	install -D -m 644 cleanup.service $(DESTDIR)/usr/lib/systemd/system/snapper-cleanup.service
 	install -D -m 644 cleanup.timer $(DESTDIR)/usr/lib/systemd/system/snapper-cleanup.timer
+	install -D -m 644 boot.service $(DESTDIR)/usr/lib/systemd/system/snapper-boot.service
+	install -D -m 644 boot.timer $(DESTDIR)/usr/lib/systemd/system/snapper-boot.timer
 
 if HAVE_ZYPP
 	install -D -m 644 zypp-plugin.conf $(DESTDIR)/etc/snapper/zypp-plugin.conf
 endif
-

--- a/data/boot.service
+++ b/data/boot.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Take snapper snapshot of root on boot
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/snapper --config root create --cleanup-algorithm number --description "boot"

--- a/data/boot.timer
+++ b/data/boot.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Take snapper snapshot of root on boot
+
+[Timer]
+OnBootSec=1
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
Fixes https://github.com/openSUSE/snapper/issues/264

The number cleanup algorithm is used for the boot configuration which makes most sense to me. I've also recently added this to the arch wiki. `-c root` clarifys the root setting, however it could also be left out.