### PR TITLE
- added prototype of proxy classes to work with and without dbus

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -13,6 +13,9 @@ snapper_SOURCES =			\
 	types.cc	types.h		\
 	commands.cc	commands.h	\
 	cleanup.cc	cleanup.h	\
+	proxy.cc	proxy.h		\
+	proxy-dbus.cc	proxy-dbus.h	\
+	proxy-lib.cc	proxy-lib.h	\
 	misc.cc		misc.h		\
 	errors.cc	errors.h
 

--- a/client/proxy-dbus.cc
+++ b/client/proxy-dbus.cc
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2016 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact Novell, Inc.
+ *
+ * To contact Novell about this file by physical or electronic mail, you may
+ * find current contact information at www.novell.com.
+ */
+
+
+#include <sstream>
+
+#include "proxy-dbus.h"
+#include "commands.h"
+#include "utils/text.h"
+
+
+using namespace std;
+
+
+ProxySnapshotDbus::ProxySnapshotDbus(ProxySnapshotsDbus* backref, unsigned int num)
+    : num(num)
+{
+    XSnapshot x = command_get_xsnapshot(*backref->backref->backref->conn,
+					backref->backref->config_name, num);
+
+    type = x.type;
+    date = x.date;
+    uid = x.uid;
+    pre_num = x.pre_num;
+    description = x.description;
+    cleanup = x.cleanup;
+    userdata = x.userdata;
+}
+
+
+ProxySnapshotDbus::ProxySnapshotDbus(SnapshotType type, unsigned int num, time_t date, uid_t uid,
+				     unsigned int pre_num, const string& description,
+				     const string& cleanup, const map<string, string>& userdata)
+    : type(type), num(num), date(date), uid(uid), pre_num(pre_num), description(description),
+      cleanup(cleanup), userdata(userdata)
+{
+}
+
+
+void
+ProxySnapperDbus::setConfigInfo(const map<string, string>& raw)
+{
+    command_set_xconfig(*backref->conn, config_name, raw);
+}
+
+
+ProxySnapshots::const_iterator
+ProxySnapperDbus::createSingleSnapshot(const SCD& scd)
+{
+    unsigned int num = command_create_single_xsnapshot(*backref->conn, config_name, scd.description,
+						       scd.cleanup, scd.userdata);
+
+    proxy_snapshots.emplace_back(new ProxySnapshotDbus(&proxy_snapshots, num));
+
+    return --proxy_snapshots.end();
+}
+
+
+ProxySnapshots::const_iterator
+ProxySnapperDbus::createPreSnapshot(const SCD& scd)
+{
+    unsigned int num = command_create_pre_xsnapshot(*backref->conn, config_name, scd.description,
+						    scd.cleanup, scd.userdata);
+
+    proxy_snapshots.emplace_back(new ProxySnapshotDbus(&proxy_snapshots, num));
+
+    return --proxy_snapshots.end();
+}
+
+
+ProxySnapshots::const_iterator
+ProxySnapperDbus::createPostSnapshot(const ProxySnapshots::const_iterator pre, const SCD& scd)
+{
+    unsigned int num = command_create_post_xsnapshot(*backref->conn, config_name, pre->getNum(),
+						     scd.description, scd.cleanup, scd.userdata);
+
+    proxy_snapshots.emplace_back(new ProxySnapshotDbus(&proxy_snapshots, num));
+
+    return --proxy_snapshots.end();
+}
+
+
+void
+ProxySnapshotsDbus::update()
+{
+    proxy_snapshots.clear();
+
+    XSnapshots x = command_list_xsnapshots(*backref->backref->conn, backref->config_name);
+    for (XSnapshots::const_iterator it = x.begin(); it != x.end(); ++it)
+	proxy_snapshots.push_back(new ProxySnapshotDbus(it->getType(), it->getNum(), it->getDate(),
+							it->getUid(), it->getPreNum(), it->getDescription(),
+							it->getCleanup(), it->getUserdata()));
+}
+
+
+const ProxySnapshots&
+ProxySnapperDbus::getSnapshots()
+{
+    proxy_snapshots.update();
+
+    return proxy_snapshots;
+}
+
+
+void
+ProxySnappersDbus::createConfig(const string& config_name, const string& subvolume,
+				const string& fstype, const string& template_name)
+{
+    command_create_xconfig(*conn, config_name, subvolume, fstype, template_name);
+}
+
+
+void
+ProxySnappersDbus::deleteConfig(const string& config_name)
+{
+    command_delete_xconfig(*conn, config_name);
+}
+
+
+ProxySnapper*
+ProxySnappersDbus::getSnapper(const string& config_name)
+{
+    for (unique_ptr<ProxySnapperDbus>& proxy_snapper : proxy_snappers)
+    {
+	if (proxy_snapper->config_name == config_name)
+	    return proxy_snapper.get();
+    }
+
+    ProxySnapperDbus* ret = new ProxySnapperDbus(this, config_name);
+    proxy_snappers.push_back(unique_ptr<ProxySnapperDbus>(ret));
+    return ret;
+}

--- a/client/proxy-dbus.h
+++ b/client/proxy-dbus.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2016 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact Novell, Inc.
+ *
+ * To contact Novell about this file by physical or electronic mail, you may
+ * find current contact information at www.novell.com.
+ */
+
+
+#ifndef SNAPPER_PROXY_DBUS_H
+#define SNAPPER_PROXY_DBUS_H
+
+
+#include "dbus/DBusMessage.h"
+#include "dbus/DBusConnection.h"
+
+#include "proxy.h"
+
+
+// TODO move code from types.{cc,h} and commands.{cc,h} to proxy-dbus.{cc,h}
+
+
+class ProxySnapshotsDbus;
+
+
+/**
+ * Concrete class of ProxySnapshot for DBus communication. Store all snapshot
+ * data in the client to avoid numerous DBus queries.
+ */
+class ProxySnapshotDbus : public ProxySnapshot::Impl
+{
+
+public:
+
+    ProxySnapshotDbus(SnapshotType type, unsigned int num, time_t date, uid_t uid,
+		      unsigned int pre_num, const string& description, const string& cleanup,
+		      const map<string, string>& userdata);
+
+    ProxySnapshotDbus(ProxySnapshotsDbus* backref, unsigned int num);
+
+    virtual SnapshotType getType() const override { return type; }
+    virtual unsigned int getNum() const override { return num; }
+    virtual time_t getDate() const override { return date; }
+    virtual uid_t getUid() const override { return uid; }
+    virtual unsigned int getPreNum() const override { return pre_num; }
+    virtual const string& getDescription() const override { return description; }
+    virtual const string& getCleanup() const override { return cleanup; }
+    virtual const map<string, string>& getUserdata() const override { return userdata; }
+
+    virtual bool isCurrent() const override { return num == 0; }
+
+    SnapshotType type;
+    unsigned int num;
+    time_t date;
+    uid_t uid;
+    unsigned int pre_num;
+    string description;
+    string cleanup;
+    map<string, string> userdata;
+
+};
+
+
+class ProxySnapperDbus;
+
+
+class ProxySnapshotsDbus : public ProxySnapshots
+{
+
+public:
+
+    ProxySnapshotsDbus(ProxySnapperDbus* backref) : backref(backref) {}
+
+    void update();
+
+    ProxySnapperDbus* backref;
+
+};
+
+
+class ProxySnappersDbus;
+
+
+class ProxySnapperDbus : public ProxySnapper
+{
+
+public:
+
+    ProxySnapperDbus(ProxySnappersDbus* backref, const string& config_name)
+	: backref(backref), config_name(config_name), proxy_snapshots(this)
+    {}
+
+    virtual void setConfigInfo(const map<string, string>& raw) override;
+
+    virtual ProxySnapshots::const_iterator createSingleSnapshot(const SCD& scd) override;
+    virtual ProxySnapshots::const_iterator createPreSnapshot(const SCD& scd) override;
+    virtual ProxySnapshots::const_iterator createPostSnapshot(const ProxySnapshots::const_iterator pre, const SCD& scd) override;
+
+    virtual const ProxySnapshots& getSnapshots() override;
+
+    ProxySnappersDbus* backref;
+
+    string config_name;
+
+    ProxySnapshotsDbus proxy_snapshots;
+
+};
+
+
+class ProxySnappersDbus : public ProxySnappers
+{
+
+public:
+
+    ProxySnappersDbus(DBus::Connection* conn)
+	: conn(conn)
+    {}
+
+    virtual void createConfig(const string& config_name, const string& subvolume,
+			      const string& fstype, const string& template_name) override;
+
+    virtual void deleteConfig(const string& config_name) override;
+
+    virtual ProxySnapper* getSnapper(const string& config_name) override;
+
+    DBus::Connection* conn;
+
+    list<std::unique_ptr<ProxySnapperDbus>> proxy_snappers;
+
+};
+
+
+#endif

--- a/client/proxy-lib.cc
+++ b/client/proxy-lib.cc
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2016 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact Novell, Inc.
+ *
+ * To contact Novell about this file by physical or electronic mail, you may
+ * find current contact information at www.novell.com.
+ */
+
+
+#include <sstream>
+#include <iostream>
+
+#include "proxy-lib.h"
+
+
+using namespace std;
+
+
+void
+ProxySnapperLib::setConfigInfo(const map<string, string>& raw)
+{
+    snapper->setConfigInfo(raw);
+}
+
+
+ProxySnapshots::const_iterator
+ProxySnapperLib::createSingleSnapshot(const SCD& scd)
+{
+    proxy_snapshots.emplace_back(new ProxySnapshotLib(snapper->createSingleSnapshot(scd)));
+
+    return --proxy_snapshots.end();
+}
+
+
+ProxySnapshots::const_iterator
+ProxySnapperLib::createPreSnapshot(const SCD& scd)
+{
+    proxy_snapshots.emplace_back(new ProxySnapshotLib(snapper->createPreSnapshot(scd)));
+
+    return --proxy_snapshots.end();
+}
+
+
+ProxySnapshots::const_iterator
+ProxySnapperLib::createPostSnapshot(const ProxySnapshots::const_iterator pre, const SCD& scd)
+{
+    const ProxySnapshotLib& x = dynamic_cast<const ProxySnapshotLib&>(pre->get_impl());
+
+    proxy_snapshots.emplace_back(new ProxySnapshotLib(snapper->createPostSnapshot(x.it, scd)));
+
+    return --proxy_snapshots.end();
+}
+
+
+void
+ProxySnapshotsLib::update()
+{
+    proxy_snapshots.clear();
+
+    Snapshots& x = backref->snapper->getSnapshots();
+    for (Snapshots::const_iterator it = x.begin(); it != x.end(); ++it)
+	proxy_snapshots.push_back(new ProxySnapshotLib(it));
+}
+
+
+const ProxySnapshots&
+ProxySnapperLib::getSnapshots()
+{
+    proxy_snapshots.update();
+
+    return proxy_snapshots;
+}
+
+
+void
+ProxySnappersLib::createConfig(const string& config_name, const string& subvolume,
+			       const string& fstype, const string& template_name)
+{
+    Snapper::createConfig(config_name, "/", subvolume, fstype, template_name);
+}
+
+
+void
+ProxySnappersLib::deleteConfig(const string& config_name)
+{
+    Snapper::deleteConfig(config_name, "/");
+}
+
+
+ProxySnapper*
+ProxySnappersLib::getSnapper(const string& config_name)
+{
+    for (unique_ptr<ProxySnapperLib>& proxy_snapper : proxy_snappers)
+    {
+	if (proxy_snapper->snapper->configName() == config_name)
+	    return proxy_snapper.get();
+    }
+
+    ProxySnapperLib* ret = new ProxySnapperLib(config_name);
+    proxy_snappers.push_back(unique_ptr<ProxySnapperLib>(ret));
+    return ret;
+}

--- a/client/proxy-lib.h
+++ b/client/proxy-lib.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2016 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact Novell, Inc.
+ *
+ * To contact Novell about this file by physical or electronic mail, you may
+ * find current contact information at www.novell.com.
+ */
+
+
+#ifndef SNAPPER_PROXY_LIB_H
+#define SNAPPER_PROXY_LIB_H
+
+
+#include "proxy.h"
+
+#include <snapper/Snapper.h>
+
+
+class ProxySnapshotLib : public ProxySnapshot::Impl
+{
+
+public:
+
+    ProxySnapshotLib(Snapshots::const_iterator it)
+	: it(it)
+    {}
+
+    virtual SnapshotType getType() const override { return it->getType(); }
+    virtual unsigned int getNum() const override { return it->getNum(); }
+    virtual time_t getDate() const override { return it->getDate(); }
+    virtual uid_t getUid() const override { return it->getUid(); }
+    virtual unsigned int getPreNum() const override { return it->getPreNum(); }
+    virtual const string& getDescription() const override { return it->getDescription(); }
+    virtual const string& getCleanup() const override { return it->getCleanup(); }
+    virtual const map<string, string>& getUserdata() const override { return it->getUserdata(); }
+
+    virtual bool isCurrent() const override { return it->isCurrent(); }
+
+    Snapshots::const_iterator it;
+
+};
+
+
+class ProxySnapperLib;
+
+
+class ProxySnapshotsLib : public ProxySnapshots
+{
+
+public:
+
+    ProxySnapshotsLib(ProxySnapperLib* backref)
+	: backref(backref)
+    {}
+
+    void update();
+
+    ProxySnapperLib* backref;
+
+};
+
+
+class ProxySnapperLib : public ProxySnapper
+{
+
+public:
+
+    ProxySnapperLib(const string& config_name)
+	: snapper(new Snapper(config_name, "/")), proxy_snapshots(this)
+    {}
+
+    virtual void setConfigInfo(const map<string, string>& raw) override;
+
+    virtual ProxySnapshots::const_iterator createSingleSnapshot(const SCD& scd) override;
+    virtual ProxySnapshots::const_iterator createPreSnapshot(const SCD& scd) override;
+    virtual ProxySnapshots::const_iterator createPostSnapshot(const ProxySnapshots::const_iterator pre, const SCD& scd) override;
+
+    virtual const ProxySnapshots& getSnapshots() override;
+
+    Snapper* snapper;
+
+    ProxySnapshotsLib proxy_snapshots;
+
+};
+
+
+class ProxySnappersLib : public ProxySnappers
+{
+
+public:
+
+    ProxySnappersLib(const string& target_root)
+	: target_root(target_root)
+    {}
+
+    virtual void createConfig(const string& config_name, const string& subvolume,
+			      const string& fstype, const string& template_name) override;
+
+    virtual void deleteConfig(const string& config_name) override;
+
+    virtual ProxySnapper* getSnapper(const string& config_name) override;
+
+    const string target_root;
+
+    list<std::unique_ptr<ProxySnapperLib>> proxy_snappers;
+
+};
+
+
+#endif

--- a/client/proxy.cc
+++ b/client/proxy.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact Novell, Inc.
+ *
+ * To contact Novell about this file by physical or electronic mail, you may
+ * find current contact information at www.novell.com.
+ */
+
+
+#include <sstream>
+#include <iostream>
+#include <algorithm>
+
+#include <snapper/AppUtil.h>
+
+#include "proxy.h"
+#include "utils/text.h"
+
+
+using namespace std;
+
+
+ProxySnapshots::const_iterator
+ProxySnapshots::findNum(const string& str) const
+{
+    istringstream s(str);
+    unsigned int num = 0;
+    s >> num;
+
+    if (s.fail() || !s.eof())
+    {
+	cerr << sformat(_("Invalid snapshot '%s'."), str.c_str()) << endl;
+	exit(EXIT_FAILURE);
+    }
+
+    const_iterator ret = find_if(proxy_snapshots.begin(), proxy_snapshots.end(), [num](const ProxySnapshot& x) { return x.getNum() == num; });
+    if (ret == proxy_snapshots.end())
+    {
+	cerr << sformat(_("Snapshot '%u' not found."), num) << endl;
+	exit(EXIT_FAILURE);
+    }
+
+    return ret;
+}
+
+
+ProxySnapshots::const_iterator
+ProxySnapshots::findPost(const_iterator pre) const
+{
+    for (const_iterator it = begin(); it != end(); ++it)
+    {
+	if (it->getType() == POST && it->getPreNum() == pre->getNum())
+	    return it;
+    }
+
+    return end();
+}

--- a/client/proxy.h
+++ b/client/proxy.h
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2016 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact Novell, Inc.
+ *
+ * To contact Novell about this file by physical or electronic mail, you may
+ * find current contact information at www.novell.com.
+ */
+
+
+#ifndef SNAPPER_PROXY_H
+#define SNAPPER_PROXY_H
+
+
+#include <memory>
+
+#include <snapper/Snapshot.h>
+
+
+using namespace snapper;
+
+
+/**
+ * The four proxy classes here allow clients, so far only the snapper command
+ * line interface, to work with and without DBus in a transparent way by
+ * providing the same interface in both cases.
+ *
+ * The main idea for providing the same interface is to have an abstract
+ * class, e.g. ProxySnapper, and two concrete implementation ProxySnapperDbus
+ * and ProxySnapperLib. This is done for ProxySnapshots, ProxySnapper and
+ * ProxySnappers.
+ *
+ * For ProxySnapshot the implementation is more complicated since
+ * ProxySnapshots provides an interface to list<ProxySnapshot> and thus
+ * polymorphism does not work. Instead ProxySnapshot has an implementation
+ * pointer (pimpl idiom) which ensures polymorphism. Another possibility would
+ * be to provide an interface to list<ProxySnapshot*> in ProxySnapshots but
+ * that is less intuitive to use.
+ *
+ * All objects are stored in containers or smart pointers to avoid manual
+ * cleanup.
+ *
+ * The interface copycats the classes Snapshot, Snapshots and Snapper of
+ * libsnapper. For consistency one may add a Snappers class to libsnapper.
+ *
+ * Limitations: The classes are tailored for the snapper command line
+ * interface. Other use-cases are not supported.
+ */
+
+
+// TODO add namespace proxy and shorter class names?
+
+// TODO maybe unique error handling, e.g. catch dbus exceptions and throw
+// snapper or new exceptions
+
+
+class ProxySnapshot
+{
+
+public:
+
+    SnapshotType getType() const { return impl->getType(); }
+    unsigned int getNum() const { return impl->getNum(); }
+    time_t getDate() const { return impl->getDate(); }
+    uid_t getUid() const { return impl->getUid(); }
+    unsigned int getPreNum() const { return impl->getPreNum(); }
+    const string& getDescription() const { return impl->getDescription(); }
+    const string& getCleanup() const { return impl->getCleanup(); }
+    const map<string, string>& getUserdata() const { return impl->getUserdata(); }
+
+    bool isCurrent() const { return impl->isCurrent(); }
+
+public:
+
+    class Impl
+    {
+
+    public:
+
+	virtual ~Impl() {}
+
+	virtual SnapshotType getType() const = 0;
+	virtual unsigned int getNum() const = 0;
+	virtual time_t getDate() const = 0;
+	virtual uid_t getUid() const = 0;
+	virtual unsigned int getPreNum() const = 0;
+	virtual const string& getDescription() const = 0;
+	virtual const string& getCleanup() const = 0;
+	virtual const map<string, string>& getUserdata() const = 0;
+
+	virtual bool isCurrent() const = 0;
+
+    };
+
+    ProxySnapshot(Impl* impl) : impl(impl) {}
+
+    const Impl& get_impl() const { return *impl; }
+
+private:
+
+    std::unique_ptr<Impl> impl;
+
+};
+
+
+class ProxySnapshots
+{
+
+public:
+
+    virtual ~ProxySnapshots() {}
+
+    typedef list<ProxySnapshot>::const_iterator const_iterator;
+    typedef list<ProxySnapshot>::size_type size_type;
+
+    const_iterator begin() const { return proxy_snapshots.begin(); }
+    const_iterator end() const { return proxy_snapshots.end(); }
+
+    const_iterator findNum(const string& str) const;
+
+    const_iterator findPost(const_iterator pre) const;
+
+    void emplace_back(ProxySnapshot::Impl* value) { proxy_snapshots.emplace_back(value); }
+
+protected:
+
+    virtual void update() = 0;
+
+    list<ProxySnapshot> proxy_snapshots;
+
+};
+
+
+class ProxySnapper
+{
+
+public:
+
+    virtual ~ProxySnapper() {}
+
+    virtual void setConfigInfo(const map<string, string>& raw) = 0;
+
+    virtual ProxySnapshots::const_iterator createSingleSnapshot(const SCD& scd) = 0;
+    virtual ProxySnapshots::const_iterator createPreSnapshot(const SCD& scd) = 0;
+    virtual ProxySnapshots::const_iterator createPostSnapshot(const ProxySnapshots::const_iterator pre, const SCD& scd) = 0;
+
+    virtual const ProxySnapshots& getSnapshots() = 0;
+
+};
+
+
+class ProxySnappers
+{
+
+public:
+
+    virtual ~ProxySnappers() {}
+
+    virtual void createConfig(const string& config_name, const string& subvolume,
+			      const string& fstype, const string& template_name) = 0;
+
+    virtual void deleteConfig(const string& config_name) = 0;
+
+    virtual ProxySnapper* getSnapper(const string& config_name) = 0;
+
+};
+
+
+#endif


### PR DESCRIPTION
For https://trello.com/c/lOl4PmBF/475-5-fate-321049-prototype-proxy-classes-for-d-bus-no-d-bus.

Solution is explanation in proxy.h. Diff for snapper.cc shows how the proxy classes replace the no_dbus-if.

The code is not finished, it is just a prototype. Not all snapper commands are based on the new classes.

Two approvals required.