### PR TITLE
Rakefile - fixed package autosubmit to Factory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ Packaging.configuration do |conf|
     # filesystems:snapper/snapper
     conf.obs_api = "https://api.opensuse.org/"
     conf.obs_project = "filesystems:snapper"
-    conf.obs_sr_project = "filesystems:snapper"
+    conf.obs_sr_project = "openSUSE:Factory"
     conf.obs_target = "openSUSE_Factory"
   end
 end


### PR DESCRIPTION
Some details:

- The `obs_api` value is obvious
- The `obs_project` value determines which OBS project is used for building and where the sources are uploaded when the build succeeds.
- The `obs_sr_project` value defines to which project a submit request is sent when a version number change is detected.
- The `obs_target` value tells which repository is used for building the package locally (in this case it's one from https://build.opensuse.org/repositories/filesystems:snapper).

That means with the original code it actually did not sent to Factory.