### PR TITLE
Run the osc source validator

### DIFF
--- a/.travis.tumbleweed.sh
+++ b/.travis.tumbleweed.sh
@@ -5,6 +5,9 @@ set -e -x
 make -f Makefile.repo
 make package
 
+# run the osc source validator to check the .spec and .changes locally
+(cd package && /usr/lib/obs/service/source_validator)
+
 # Build the binary package locally, use plain "rpmbuild" to make it simple.
 # "osc build" is too resource hungry (builds a complete chroot from scratch).
 # Moreover it does not work in a Docker container (it fails when trying to mount

--- a/Dockerfile.leap
+++ b/Dockerfile.leap
@@ -16,6 +16,7 @@ RUN zypper --non-interactive in --no-recommends \
   libtool \
   libxml2-devel \
   libxslt \
+  obs-service-source_validator \
   pam-devel \
   rpm-build \
   which

--- a/Dockerfile.tumbleweed
+++ b/Dockerfile.tumbleweed
@@ -16,6 +16,7 @@ RUN zypper --non-interactive in --no-recommends \
   libtool \
   libxml2-devel \
   libxslt \
+  obs-service-source_validator \
   pam-devel \
   rpm-build \
   which


### PR DESCRIPTION
Run the osc source validator in the openSUSE based Travis builds.

Similar to the https://github.com/yast/docker-yast-cpp/pull/1 and https://github.com/yast/docker-yast-ruby/pull/2 pull requests, run the OBS source validator also here.

I found out that in [this YaST PR](https://github.com/yast/yast-packager/pull/225) build succeeded at Travis but [failed in Jenkins](https://ci.opensuse.org/job/yast-packager-github-push/231//console). It turned out that the Jenkins failure was caused by a wrong changelog sequence (dates not in ascending order) which was not tested at Travis.

This is the same enhancement also for snapper.