### PR TITLE
Fixed crontab packaging in Debian

### DIFF
--- a/dists/debian/rules
+++ b/dists/debian/rules
@@ -21,3 +21,5 @@ override_dh_auto_configure:
 override_dh_auto_install:
 	dh_auto_install
 	install -D -m 644 data/sysconfig.snapper $$(pwd)/debian/tmp/etc/sysconfig/snapper
+	mv $$(pwd)/debian/tmp/etc/cron.hourly/suse.de-snapper $$(pwd)/debian/tmp/etc/cron.hourly/snapper
+	mv $$(pwd)/debian/tmp/etc/cron.daily/suse.de-snapper $$(pwd)/debian/tmp/etc/cron.daily/snapper

--- a/dists/debian/snapper.install
+++ b/dists/debian/snapper.install
@@ -1,5 +1,5 @@
-etc/cron.daily/suse.de-snapper etc/cron.daily/snapper
-etc/cron.hourly/suse.de-snapper etc/cron.hourly/snapper
+etc/cron.daily/snapper
+etc/cron.hourly/snapper
 etc/dbus-1/system.d/org.opensuse.Snapper.conf
 etc/logrotate.d/snapper
 usr/bin/snapper


### PR DESCRIPTION
- Fixes issue #328 
- By mistake the crontab files were installed into `/etc/cron.*/snapper/suse.de-snapper` files.
- The move/rename has been fixed.
- Verified with manual package rebuild:
```
dpkg -c snapper_*.deb | grep "cron.*snapper"
-rwxr-xr-x root/root       744 2017-02-28 16:22 ./etc/cron.daily/snapper
-rwxr-xr-x root/root       514 2017-02-28 16:22 ./etc/cron.hourly/snapper
```