### PR TITLE
- use python3 instead of python2 (bsc#1070324)

### DIFF
--- a/Dockerfile.tumbleweed
+++ b/Dockerfile.tumbleweed
@@ -4,13 +4,15 @@ FROM opensuse:tumbleweed
 RUN zypper --non-interactive in --no-recommends \
   autoconf \
   automake \
-  boost-devel \
   dbus-1-devel \
   docbook-xsl-stylesheets \
   e2fsprogs-devel \
   gcc-c++ \
   grep \
   libacl-devel \
+  libboost_system-devel \
+  libboost_test-devel \
+  libboost_thread-devel \
   libbtrfs-devel \
   libmount-devel \
   libtool \

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,8 @@ snapper-$(VERSION).tar.bz2: dist-bzip2
 
 DEBIAN_FLAVOURS =	\
     Debian_7.0		\
-    Debian_8.0
+    Debian_8.0		\
+    Debian_9.0
 
 UBUNTU_FLAVOURS =	\
     xUbuntu_14.04	\
@@ -24,7 +25,8 @@ UBUNTU_FLAVOURS =	\
     xUbuntu_15.10	\
     xUbuntu_16.04	\
     xUbuntu_16.10	\
-    xUbuntu_17.04
+    xUbuntu_17.04	\
+    xUbuntu_17.10
 
 show-debian:
 	@echo "Debian flavors: $(DEBIAN_FLAVOURS)"

--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jan 10 14:33:11 CET 2018 - aschnell@suse.com
+
+- use python3 instead of python2 (bsc#1070324)
+
+-------------------------------------------------------------------
 Thu Nov 23 13:51:45 UTC 2017 - rbrown@suse.com
 
 - Replace references to /var/adm/fillup-templates with new 

--- a/scripts/zypp-plugin.py
+++ b/scripts/zypp-plugin.py
@@ -1,7 +1,7 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (c) [2011-2014] Novell, Inc.
-# Copyright (c) [2015] SUSE LLC
+# Copyright (c) [2015,2018] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/snapper.spec.in
+++ b/snapper.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package snapper
 #
-# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -210,11 +210,10 @@ libsnapper.
 
 %package -n snapper-zypp-plugin
 BuildArch:	noarch
-Requires:       dbus-1-python
 Requires:       libzypp(plugin:commit) = 1
-Requires:	python-xml
+Requires:	python3-dbus-python
+Requires:	python3-zypp-plugin
 Requires:       snapper = %version
-Requires:       zypp-plugin-python
 Summary:        A zypp commit plugin for calling snapper
 Group:          System/Packages
 


### PR DESCRIPTION
For https://trello.com/c/WHyQEPuE/203-2-sles15-beta5-p2-1070324-snapper-zypp-plugin-still-uses-python2.