### PR TITLE
Update the distro versions used at Travis

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,5 +1,5 @@
-# Build Debian 8 image
-FROM debian:8
+# Build Debian 9 image
+FROM debian:9
 
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/run
 RUN apt-get update && \

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -1,5 +1,5 @@
-# Build Fedora 25 image
-FROM fedora:25
+# Build Fedora 27 image
+FROM fedora:27
 
 RUN dnf -y install \
   autoconf \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,5 +1,5 @@
-# Build Ubuntu 16.10 image
-FROM ubuntu:16.10
+# Build Ubuntu 17.10 image
+FROM ubuntu:17.10
 
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/run
 RUN apt-get update && \


### PR DESCRIPTION
## Summary 
- Use newer distros at Travis
- I do not think we should still build for the older ones, we should focus on the newer versions. But if needed the older versions can be added and built in parallel...

### Version Updates
- Debian 8 -> 9
- Fedora 25 -> 27
- Ubuntu 16.10 -> 17.10