### PR TITLE
Build reproducible tarballs by "make package"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -60,9 +60,32 @@ package-clean:
 # VERSION file.
 #
 # $< is the first depencency of the rule, i.e. snapper-$(VERSION).tar.gz in this case.
-#
+
+# Build a reproducible tarball:
+# - set the file time stamps according to the latest commit
+# - sort the files (in a locale independent way, use the NULL separator to
+#   correctly process also the file names containing a new line)
+#   Note: tar >= 1.28 supports "--sort=name" option, unfortunately
+#   Leap 42.3 and SLES12-SP3 contain version 1.27.1
+# - use the GNU format (the default POSIX format contains some time stamps)
+# - set the owner and group to "root"
+# - set the fixed modification time
+
+# shared tar options
+EXTRA_TAR_OPTIONS = --format=gnu --owner=root --group=root \
+--mtime='$(shell git show -s --format=%ci)' --null --files-from -
+
+# redefine the standard automake "tar" command
+am__tar=find "$$tardir" -type f -print0 | LC_ALL=C sort -z | \
+  tar -c -f - $(EXTRA_TAR_OPTIONS)
+
 package: snapper-$(VERSION).tar.bz2 package-clean
-	tar cfzv package/debian.tar.gz --transform='s|dists/||' --show-transformed --exclude='*.in' dists/debian/*
+	find dists/debian -not -name '*.in' -not -name '.*' -type f -print0 | \
+	  LC_ALL=C sort -z | \
+	  tar -c -f package/debian.tar --transform='s|dists/||' --show-transformed \
+			$(EXTRA_TAR_OPTIONS)
+	## use -n option to exclude the original file time stamps to have a reproducible tarball
+	gzip -n package/debian.tar
 	cp dists/debian/*.dsc.in package/
 	echo "$(shell md5sum $< | sed -e 's/\s.*//') $(shell wc -c $<)" >> package/snapper-Debian.dsc.in
 	echo "$(shell md5sum $< | sed -e 's/\s.*//') $(shell wc -c $<)" >> package/snapper-xUbuntu.dsc.in


### PR DESCRIPTION
- `make package` now builds reproducible tarballs (1:1 bit copy with the same checksum)
- Makes the Open Build Service submissions easier (the internal and external OBS will contain the same tarballs regardless where/when they are build)
- Similar solution as used in https://github.com/openSUSE/packaging_rake_tasks/pull/43 and https://github.com/openSUSE/packaging_rake_tasks/pull/44

Runnig `make package` now always produces the same result:

```console
> make package > /dev/null
> sha1sum package/snapper-0.5.3.tar.bz2 package/debian.tar.gz 
02a9eeb9447eb0ea8de56ff549a48d165d71012f  package/snapper-0.5.3.tar.bz2
ddc6b7e289a95fa7ae9cc491d403470e423b21ea  package/debian.tar.gz
> rm package/snapper-0.5.3.tar.bz2 package/debian.tar.gz 
> make package > /dev/null
> sha1sum package/snapper-0.5.3.tar.bz2 package/debian.tar.gz 
02a9eeb9447eb0ea8de56ff549a48d165d71012f  package/snapper-0.5.3.tar.bz2
ddc6b7e289a95fa7ae9cc491d403470e423b21ea  package/debian.tar.gz

```