### PR TITLE
Command was wrongly translated

### DIFF
--- a/po/nl.po
+++ b/po/nl.po
@@ -147,7 +147,7 @@ msgstr "\tsnapper cleanup <opschoonalgoritme>"
 
 #: ../client/snapper.cc:691
 msgid "\tsnapper create"
-msgstr "\tsnapper aanmaken"
+msgstr "\tsnapper create"
 
 #: ../client/snapper.cc:271
 msgid "\tsnapper create-config <subvolume>"


### PR DESCRIPTION
Someone translated the command "snapper create" wrongly to Dutch. I undid that