### PR TITLE
- create subvolume instead of snapshot for initial system 

### DIFF
--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,9 +1,15 @@
 -------------------------------------------------------------------
+Mon Jan 29 11:32:56 CET 2018 - aschnell@suse.com
+
+- create subvolume instead of snapshot for initial system
+  (bsc#1077240)
+- version 0.5.4
+
+-------------------------------------------------------------------
 Fri Jan 26 14:36:20 CET 2018 - aschnell@suse.com
 
 - improved error handling for systemd services
   (gh#openSUSE/snapper#382)
-- version 0.5.4
 
 -------------------------------------------------------------------
 Wed Jan 10 14:33:11 CET 2018 - aschnell@suse.com

--- a/snapper/Btrfs.cc
+++ b/snapper/Btrfs.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2011-2015] Novell, Inc.
- * Copyright (c) [2016-2017] SUSE LLC
+ * Copyright (c) [2016-2018] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -305,8 +305,8 @@ namespace snapper
 
 
     void
-    Btrfs::createSnapshot(unsigned int num, unsigned int num_parent, bool read_only,
-			  bool quota) const
+    Btrfs::createSnapshot(unsigned int num, unsigned int num_parent, bool read_only, bool quota,
+			  bool empty) const
     {
 	if (num_parent == 0)
 	{
@@ -315,8 +315,11 @@ namespace snapper
 
 	    try
 	    {
-		create_snapshot(subvolume_dir.fd(), info_dir.fd(), "snapshot", read_only,
-				quota ? qgroup : no_qgroup);
+		if (empty)
+		    create_subvolume(info_dir.fd(), "snapshot");
+		else
+		    create_snapshot(subvolume_dir.fd(), info_dir.fd(), "snapshot", read_only,
+				    quota ? qgroup : no_qgroup);
 	    }
 	    catch (const runtime_error& e)
 	    {

--- a/snapper/Btrfs.h
+++ b/snapper/Btrfs.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2011-2015] Novell, Inc.
- * Copyright (c) [2016-2017] SUSE LLC
+ * Copyright (c) [2016-2018] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -68,7 +68,7 @@ namespace snapper
 	SDir openGeneralDir() const;
 
 	virtual void createSnapshot(unsigned int num, unsigned int num_parent, bool read_only,
-				    bool quota) const;
+				    bool quota, bool empty) const;
 	virtual void createSnapshotOfDefault(unsigned int num, bool read_only, bool quota) const;
 	virtual void deleteSnapshot(unsigned int num) const;
 

--- a/snapper/Ext4.cc
+++ b/snapper/Ext4.cc
@@ -164,7 +164,8 @@ namespace snapper
 
 
     void
-    Ext4::createSnapshot(unsigned int num, unsigned int num_parent, bool read_only, bool quota) const
+    Ext4::createSnapshot(unsigned int num, unsigned int num_parent, bool read_only, bool quota,
+			 bool empty) const
     {
 	if (num_parent != 0 || !read_only)
 	    throw std::logic_error("not implemented");

--- a/snapper/Ext4.h
+++ b/snapper/Ext4.h
@@ -50,8 +50,8 @@ namespace snapper
 	virtual SDir openInfosDir() const;
 	virtual SDir openSnapshotDir(unsigned int num) const;
 
-	virtual void createSnapshot(unsigned int num, unsigned int num_parent,
-				    bool read_only, bool quota) const;
+	virtual void createSnapshot(unsigned int num, unsigned int num_parent, bool read_only,
+				    bool quota, bool empty) const;
 	virtual void deleteSnapshot(unsigned int num) const;
 
 	virtual bool isSnapshotMounted(unsigned int num) const;

--- a/snapper/Filesystem.h
+++ b/snapper/Filesystem.h
@@ -69,7 +69,7 @@ namespace snapper
 	virtual SDir openSnapshotDir(unsigned int num) const = 0;
 
 	virtual void createSnapshot(unsigned int num, unsigned int num_parent, bool read_only,
-				    bool quota) const = 0;
+				    bool quota, bool empty) const = 0;
 	virtual void createSnapshotOfDefault(unsigned int num, bool read_only, bool quota) const;
 	virtual void deleteSnapshot(unsigned int num) const = 0;
 

--- a/snapper/Lvm.cc
+++ b/snapper/Lvm.cc
@@ -259,7 +259,8 @@ namespace snapper
 
 
     void
-    Lvm::createSnapshot(unsigned int num, unsigned int num_parent, bool read_only, bool quota) const
+    Lvm::createSnapshot(unsigned int num, unsigned int num_parent, bool read_only, bool quota,
+			bool empty) const
     {
 	if (num_parent != 0 || !read_only)
 	    throw std::logic_error("not implemented");

--- a/snapper/Lvm.h
+++ b/snapper/Lvm.h
@@ -96,8 +96,8 @@ namespace snapper
 	virtual SDir openInfosDir() const;
 	virtual SDir openSnapshotDir(unsigned int num) const;
 
-	virtual void createSnapshot(unsigned int num, unsigned int num_parent,
-				    bool read_only, bool quota) const;
+	virtual void createSnapshot(unsigned int num, unsigned int num_parent, bool read_only,
+				    bool quota, bool empty) const;
 	virtual void deleteSnapshot(unsigned int num) const;
 
 	virtual bool isSnapshotMounted(unsigned int num) const;

--- a/snapper/Snapshot.cc
+++ b/snapper/Snapshot.cc
@@ -522,12 +522,13 @@ namespace snapper
 
 
     void
-    Snapshot::createFilesystemSnapshot(unsigned int num_parent, bool read_only) const
+    Snapshot::createFilesystemSnapshot(unsigned int num_parent, bool read_only, bool empty) const
     {
 	if (isCurrent())
 	    SN_THROW(IllegalSnapshotException());
 
-	snapper->getFilesystem()->createSnapshot(num, num_parent, read_only, !cleanup.empty());
+	snapper->getFilesystem()->createSnapshot(num, num_parent, read_only, !cleanup.empty(),
+						 empty);
     }
 
 
@@ -561,9 +562,9 @@ namespace snapper
 	snapshot.uid = scd.uid;
 	snapshot.description = scd.description;
 	snapshot.cleanup = scd.cleanup;
-	snapshot.userdata =scd. userdata;
+	snapshot.userdata = scd.userdata;
 
-	return createHelper(snapshot, getSnapshotCurrent(), scd.read_only);
+	return createHelper(snapshot, getSnapshotCurrent(), scd.read_only, scd.empty);
     }
 
 
@@ -633,7 +634,8 @@ namespace snapper
 
 
     Snapshots::iterator
-    Snapshots::createHelper(Snapshot& snapshot, const_iterator parent, bool read_only)
+    Snapshots::createHelper(Snapshot& snapshot, const_iterator parent, bool read_only,
+			    bool empty)
     {
 	// parent == end indicates the btrfs default subvolume. Unclean, but
 	// adding a special snapshot like current needs too many API changes.
@@ -641,7 +643,7 @@ namespace snapper
 	try
 	{
 	    if (parent != end())
-		snapshot.createFilesystemSnapshot(parent->getNum(), read_only);
+		snapshot.createFilesystemSnapshot(parent->getNum(), read_only, empty);
 	    else
 		snapshot.createFilesystemSnapshotOfDefault(read_only);
 	}

--- a/snapper/Snapshot.h
+++ b/snapper/Snapshot.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2011-2015] Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016,2018] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -150,7 +150,7 @@ namespace snapper
 
 	void writeInfo() const;
 
-	void createFilesystemSnapshot(unsigned int num_parent, bool read_only) const;
+	void createFilesystemSnapshot(unsigned int num_parent, bool read_only, bool empty) const;
 	void createFilesystemSnapshotOfDefault(bool read_only) const;
 	void deleteFilesystemSnapshot() const;
 
@@ -181,9 +181,16 @@ namespace snapper
     {
     public:
 
-	SCD() : SMD(), read_only(true), uid(0) {}
+	SCD() : SMD(), read_only(true), empty(false), uid(0) {}
 
 	bool read_only;
+
+	/**
+	 * Create an empty snapshot. For btrfs this creates a subvolume
+	 * instead of a snapshot, for other filesystem types ignored.
+	 */
+	bool empty;
+
 	uid_t uid;
 
     };
@@ -236,7 +243,8 @@ namespace snapper
 	iterator createPreSnapshot(const SCD& scd);
 	iterator createPostSnapshot(const_iterator pre, const SCD& scd);
 
-	iterator createHelper(Snapshot& snapshot, const_iterator parent, bool read_only);
+	iterator createHelper(Snapshot& snapshot, const_iterator parent, bool read_only,
+			      bool empty = false);
 
 	void modifySnapshot(iterator snapshot, const SMD& smd);
 


### PR DESCRIPTION
- create subvolume instead of snapshot for initial system (https://bugzilla.suse.com/show_bug.cgi?id=1077240)