### PR TITLE
Use 'idle' IO and cpu scheduling class for cleanup service to prevent slowdown of systems

### DIFF
--- a/data/cleanup.service
+++ b/data/cleanup.service
@@ -6,4 +6,5 @@ Documentation=man:snapper(8) man:snapper-configs(5)
 [Service]
 Type=simple
 ExecStart=/usr/lib/snapper/systemd-helper --cleanup
-
+IOSchedulingClass=idle
+CPUSchedulingPolicy=idle


### PR DESCRIPTION
Related to https://bugzilla.suse.com/show_bug.cgi?id=1063638 . Not only btrfs
maintenance tasks can bring systems to a halt or at least slow down and they
already set idle a class.