### PR TITLE
Set timeline.service as Type=oneshot to allow serial odering

### DIFF
--- a/data/timeline.service
+++ b/data/timeline.service
@@ -4,6 +4,6 @@ Description=Timeline of Snapper Snapshots
 Documentation=man:snapper(8) man:snapper-configs(5)
 
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=/usr/lib/snapper/systemd-helper --timeline
 


### PR DESCRIPTION
Systemd starts units in parallel unless otherwise specified by the unit files. A `Type=simple` service has no such constraint, and as such any `WantedBy` service introduced to run after `snapper-timeline.service` will execute in parallel instead of waiting until snapper is finished. By changing `simple` to `oneshot`, other units can be added to the system that use `WantedBy=snapper-timeline.service` and they will actually run after `snapper-timeline.service` is finished. When `snapper-timeline.service` is installed by itself this has no effect, and the unit continues to operate as it did for anyone that doesn't have any dependent services.

Example Before: 

```
Feb 06 05:00:01 localhost systemd[1]: Started Timeline of Snapper Snapshots.
Feb 06 05:00:01 localhost systemd[1]: Started Borg backup post snapper snapshots.
Feb 06 05:00:01 localhost systemd-helper[15627]: running timeline for 'home'.
Feb 06 05:00:01 localhost systemd-helper[15627]: running timeline for 'root'.
Feb 06 05:00:01 localhost systemd-helper[15627]: running timeline for 'usr'.
Feb 06 05:00:02 localhost snapper2borg.sh[15628]: borg create -x -s -C auto,zstd /mnt/external1/backups/home::home-snapshot84 /tmp/borg/fedora-home
Feb 06 05:00:02 localhost systemd-helper[15627]: running timeline for 'var'.
Feb 06 05:00:02 localhost snapper2borg.sh[15628]: borg create -x -s -C auto,zstd /mnt/external1/backups/root::root-snapshot84 /tmp/borg/fedora-root
Feb 06 05:00:02 localhost snapper2borg.sh[15628]: borg create -x -s -C auto,zstd /mnt/external1/backups/usr::usr-snapshot83 /tmp/borg/fedora-usr
Feb 06 05:00:02 localhost snapper2borg.sh[15628]: borg create -x -s -C auto,zstd /mnt/external1/backups/var::var-snapshot83 /tmp/borg/fedora-var
```

Note how the two units outputs are interleaved because in the beginning they are started in parallel. Also note the actual issue, which is that my script picks up two older-numbered snapshots because of a race condition caused by not ordering this properly. 

Example After:

```
Feb 06 05:52:26 localhost systemd[1]: Starting Timeline of Snapper Snapshots...
Feb 06 05:52:26 localhost systemd-helper[28935]: running timeline for 'home'.
Feb 06 05:52:26 localhost systemd-helper[28935]: running timeline for 'root'.
Feb 06 05:52:26 localhost systemd-helper[28935]: running timeline for 'usr'.
Feb 06 05:52:27 localhost systemd-helper[28935]: running timeline for 'var'.
Feb 06 05:52:27 localhost systemd[1]: Started Timeline of Snapper Snapshots.
Feb 06 05:52:27 localhost systemd[1]: Started Borg backup post snapper snapshots.
Feb 06 05:52:32 localhost snapper2borg.sh[29007]: borg create -x -s -C auto,zstd /mnt/external1/backups/home::home-snapshot99 /tmp/borg/fedora-home
Feb 06 05:52:32 localhost snapper2borg.sh[29007]: borg create -x -s -C auto,zstd /mnt/external1/backups/root::root-snapshot99 /tmp/borg/fedora-root
Feb 06 05:52:33 localhost snapper2borg.sh[29007]: borg create -x -s -C auto,zstd /mnt/external1/backups/usr::usr-snapshot99 /tmp/borg/fedora-usr
Feb 06 05:52:33 localhost snapper2borg.sh[29007]: borg create -x -s -C auto,zstd /mnt/external1/backups/var::var-snapshot99 /tmp/borg/fedora-var
```

The unit that is running after:

```
# /etc/systemd/system/snapper2borg.service
[Unit]
Description=Borg backup post snapper snapshots
After=snapper-timeline.service

[Service]
Type=idle
ExecStart=/usr/local/bin/snapper2borg.sh

[Install]
WantedBy=snapper-timeline.service
```
