### PR TITLE
Add missing pthread library for server

### DIFF
--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -14,4 +14,4 @@ snapperd_SOURCES =					\
 	Types.cc		Types.h
 
 snapperd_LDADD = ../snapper/libsnapper.la ../dbus/libdbus.la -lrt
-snapperd_LDFLAGS = -lboost_system -lboost_thread
+snapperd_LDFLAGS = -lboost_system -lboost_thread -lpthread


### PR DESCRIPTION
While building snapper with Boost 1.67, the following error
occurred,

```
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: Client.o: undefined reference to symbol 'pthread_condattr_setclock@@GLIBC_2.3.3'
/lib64/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:440: snapperd] Error 1
make[2]: Leaving directory '/home/abuild/rpmbuild/BUILD/snapper-0.5.4/server'
```