### PR TITLE
Link the dbus library with the boost libraries (Fixes #424)

### DIFF
--- a/dbus/Makefile.am
+++ b/dbus/Makefile.am
@@ -12,4 +12,4 @@ libdbus_la_SOURCES =					\
 	DBusMainLoop.cc		DBusMainLoop.h
 
 libdbus_la_LIBADD = $(DBUS_LIBS)
-
+libdbus_la_LDFLAGS = -lboost_system -lboost_thread


### PR DESCRIPTION
This fixes a build problem in Ubuntu on armhf where an unresolved symbol
was reported.