### PR TITLE
- updated debian changelog

### DIFF
--- a/dists/debian/changelog
+++ b/dists/debian/changelog
@@ -1,3 +1,9 @@
+snapper (0.6.0) stable; urgency=low
+
+  * Updated to version 0.6.0
+
+ -- Arvin Schnell <aschnell@suse.com>  Thu, 04 Oct 2018 11:49:32 +0200
+
 snapper (0.5.6) stable; urgency=low
 
   * Updated to version 0.5.6


### PR DESCRIPTION
For https://trello.com/c/Mm12Zg7N/296-fate-323843-show-unique-space-consumed-by-snapshot-in-snapper-list and as explained in README.md.