### PR TITLE
Ensure also "timeline" runs with 'idle' IO and CPU scheduling {boo#1099494)

### DIFF
--- a/data/timeline.service
+++ b/data/timeline.service
@@ -6,4 +6,6 @@ Documentation=man:snapper(8) man:snapper-configs(5)
 [Service]
 Type=simple
 ExecStart=/usr/lib/snapper/systemd-helper --timeline
+IOSchedulingClass=idle
+CPUSchedulingPolicy=idle
 


### PR DESCRIPTION
With https://github.com/openSUSE/snapper/pull/391 we already asked the
background "cleanup" service to take idle IO and CPU priority so for
sake of consistency and potentially fix bad responsiveness of systems
also the timeline service should be triggered the same.

This change is motivated by an observation I made on my own system: The
timeline service was triggered at around the same time a personal sync
and backup script was triggered. Then the system turned unresponsive for
some minutes. I guess asking the timeline service to act with idle
priority might help a bit in similar situations.