### PR TITLE
btrfs: do not wrongly report failure when doing btrfs comparison

### DIFF
--- a/snapper/Btrfs.cc
+++ b/snapper/Btrfs.cc
@@ -1235,6 +1235,8 @@ namespace snapper
     bool
     StreamProcessor::dumper(int fd)
     {
+	unsigned int count = 0;
+
 	while (true)
 	{
 	    boost::this_thread::interruption_point();
@@ -1248,7 +1250,10 @@ namespace snapper
 	    r = btrfs_read_and_process_send_stream(fd, &send_ops, &*this, 0, 1);
 #endif
 
-	    if (r < 0)
+	    /* We only return an error when r == -ENODATA if this was the first
+	     * call to btrfs_read_and_process_send_stream.
+	     */
+	    if (r < 0 && !(r == -ENODATA && count > 0))
 	    {
 		y2err("btrfs_read_and_process_send_stream failed");
 
@@ -1258,6 +1263,7 @@ namespace snapper
 
 		return false;
 	    }
+	    count++;
 
 	    if (r)
 	    {


### PR DESCRIPTION
snapper would always fail using btrfs features to perform a comparison
between two read-only snapshots, and fallback to calling stat on each
file.

The reason was that `btrfs_read_and_process_send_stream` would first
return 0, because it successfully did its work, and the second time
it would return -ENODATA, because no more data was present in the
stream to be processed.

We now check that we fail due to ENODATA only if it was the first time
we tried to call `btrfs_read_and_process_send_stream`.

In my case, a comparison took initially ~30s, and came down to ~300ms
with this fix.