### PR TITLE
Fix IO error when determining the snapshot for the default subvolume

### DIFF
--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 21 18:59:09 CET 2018 - gergo@borus.hu
+
+- validate snapshot id corresponding to the default subvolume
+  before using it for the current config (gh#openSUSE/snapper#449)
+
+-------------------------------------------------------------------
 Mon Oct 29 10:38:59 CET 2018 - aschnell@suse.com
 
 - extended space aware cleanup algorithm to ensure minimal

--- a/snapper/Btrfs.cc
+++ b/snapper/Btrfs.cc
@@ -1463,6 +1463,9 @@ namespace snapper
 
 	unsigned int num = stoi(rx.cap(1));
 
+	if (!checkSnapshot(num))
+	    return make_pair(false, 0);
+
 	if (get_id(openSnapshotDir(num).fd()) != id)
 	    return make_pair(false, 0);
 

--- a/snapper/FileUtils.cc
+++ b/snapper/FileUtils.cc
@@ -84,8 +84,11 @@ namespace snapper
 
 	dirfd = ::openat(dir.dirfd, name.c_str(), O_RDONLY | O_NOFOLLOW | O_NOATIME | O_CLOEXEC);
 	if (dirfd < 0)
-	    SN_THROW(IOErrorException(sformat("open failed path:%s errno:%d (%s)", dir.fullname().c_str(),
+	{
+	    string failed_path = dir.fullname() + "/" + name;
+	    SN_THROW(IOErrorException(sformat("open failed path:%s errno:%d (%s)", failed_path.c_str(),
 					      errno, stringerror(errno).c_str())));
+	}
 
 	struct stat buf;
 	if (fstat(dirfd, &buf) != 0)


### PR DESCRIPTION
When several configs are present on the same btrfs filesystem, the snapshot id corresponding to the default subvolume may not belong to the currently listed config and an attempt to open the non-existing snapshot leads to IO Error.

This should fix #449 