### PR TITLE
[WIP] Ensure snapperd runs with 'idle' IO and CPU scheduling (boo#1099494)

### DIFF
--- a/data/cleanup.service
+++ b/data/cleanup.service
@@ -6,5 +6,3 @@ Documentation=man:snapper(8) man:snapper-configs(5)
 [Service]
 Type=simple
 ExecStart=/usr/lib/snapper/systemd-helper --cleanup
-IOSchedulingClass=idle
-CPUSchedulingPolicy=idle

--- a/data/org.opensuse.Snapper.service
+++ b/data/org.opensuse.Snapper.service
@@ -1,5 +1,5 @@
 # DBus service activation config
 [D-BUS Service]
 Name=org.opensuse.Snapper
-Exec=/usr/sbin/snapperd
+Exec=/usr/bin/nice /usr/bin/ionice -c 3 /usr/sbin/snapperd
 User=root


### PR DESCRIPTION
With https://github.com/openSUSE/snapper/pull/391 we already asked the
background "cleanup" service to take idle IO and CPU priority so for
sake of consistency and potentially fix bad responsiveness of systems
the snapperd service which is triggered over dbus should be asked to run
in a 'nice' way.

This change is motivated by an observation I made on my own system: The
timeline service was triggered at around the same time a personal sync
and backup script was triggered. Then the system turned unresponsive for
some minutes. I guess asking the snapperd service to act with idle
priority might help a bit in similar situations.

Changing the the timeline or cleanup service does not help as they would
only trigger snapperd and not produce significant IO themselves and the
nice levels are not communicated to snapperd otherwise.

I have been running this change for some days now and did not observe
any problems. I could ensure that snapperd would still start up and
trigger the necessary actions and I have not observed any negative
impact so it might fix the original issue but this is not ensured.