### PR TITLE
Add option to disable qgroup rescan when listing snapshots

### DIFF
--- a/client/commands.cc
+++ b/client/commands.cc
@@ -494,6 +494,24 @@ command_get_xfiles(DBus::Connection& conn, const string& config_name, unsigned i
 }
 
 
+bool
+command_is_quota_enabled(DBus::Connection& conn, const string& config_name)
+{
+    DBus::MessageMethodCall call(SERVICE, OBJECT, INTERFACE, "IsQuotaEnabled");
+
+    DBus::Hoho hoho(call);
+    hoho << config_name;
+
+    DBus::Message reply = conn.send_with_reply_and_block(call);
+    bool is_quota_enabled = false;
+
+    DBus::Hihi hihi(reply);
+    hihi >> is_quota_enabled;
+
+    return is_quota_enabled;
+}
+
+
 void
 command_setup_quota(DBus::Connection& conn, const string& config_name)
 {

--- a/client/commands.h
+++ b/client/commands.h
@@ -126,6 +126,9 @@ vector<XFile>
 command_get_xfiles(DBus::Connection& conn, const string& config_name, unsigned int number1,
 		   unsigned int number2);
 
+bool
+command_is_quota_enabled(DBus::Connection& conn, const string& config_name);
+
 void
 command_setup_quota(DBus::Connection& conn, const string& config_name);
 

--- a/client/proxy-dbus.cc
+++ b/client/proxy-dbus.cc
@@ -154,6 +154,13 @@ ProxySnapperDbus::setConfig(const ProxyConfig& proxy_config)
 }
 
 
+bool
+ProxySnapperDbus::isQuotaEnabled() const
+{
+    return command_is_quota_enabled(conn(), config_name);
+}
+
+
 void
 ProxySnapperDbus::setupQuota()
 {

--- a/client/proxy-dbus.h
+++ b/client/proxy-dbus.h
@@ -141,6 +141,8 @@ public:
     virtual ProxySnapshots& getSnapshots() override { return proxy_snapshots; }
     virtual const ProxySnapshots& getSnapshots() const override { return proxy_snapshots; }
 
+    virtual bool isQuotaEnabled() const override;
+
     virtual void setupQuota() override;
 
     virtual void prepareQuota() const override;

--- a/client/proxy-lib.h
+++ b/client/proxy-lib.h
@@ -124,6 +124,8 @@ public:
     virtual ProxySnapshots& getSnapshots() override { return proxy_snapshots; }
     virtual const ProxySnapshots& getSnapshots() const override { return proxy_snapshots; }
 
+    virtual bool isQuotaEnabled() const override { return snapper->isQuotaEnabled(); }
+
     virtual void setupQuota() override { snapper->setupQuota(); }
 
     virtual void prepareQuota() const override { snapper->prepareQuota(); }

--- a/client/proxy.h
+++ b/client/proxy.h
@@ -235,6 +235,8 @@ public:
     virtual ProxySnapshots& getSnapshots() = 0;
     virtual const ProxySnapshots& getSnapshots() const = 0;
 
+    virtual bool isQuotaEnabled() const = 0;
+
     virtual void setupQuota() = 0;
 
     virtual void prepareQuota() const = 0;

--- a/client/snapper.cc
+++ b/client/snapper.cc
@@ -452,6 +452,11 @@ list_from_one_config(ProxySnapper* snapper, ListMode list_mode, bool show_used_s
     {
 	default_snapshot = snapshots.getDefault();
 	active_snapshot = snapshots.getActive();
+
+	if (show_used_space)
+	{
+	    show_used_space = snapper->isQuotaEnabled();
+	}
     }
     catch (const DBus::ErrorException& e)
     {

--- a/client/snapper.cc
+++ b/client/snapper.cc
@@ -356,6 +356,7 @@ help_list()
 	 << _("    Options for 'list' command:") << '\n'
 	 << _("\t--type, -t <type>\t\tType of snapshots to list.") << '\n'
 	 << _("\t--disable-used-space\t\tDisable showing used space.") << '\n'
+	 << _("\t--no-used-space-update\t\tDo not update used space information.") << '\n'
 	 << _("\t--all-configs, -a\t\tList snapshots from all accessible configs.") << '\n'
 	 << endl;
 }
@@ -364,7 +365,7 @@ enum ListMode { LM_ALL, LM_SINGLE, LM_PRE_POST };
 
 
 void
-list_from_one_config(ProxySnapper* snapper, ListMode list_mode, bool show_used_space);
+list_from_one_config(ProxySnapper* snapper, ListMode list_mode, bool show_used_space, bool update_used_space);
 
 
 void
@@ -373,6 +374,7 @@ command_list(ProxySnappers* snappers, ProxySnapper*)
     const struct option options[] = {
 	{ "type",		required_argument,	0,	't' },
 	{ "disable-used-space", no_argument,            0,      0 },
+	{ "no-used-space-update",no_argument,		0,	0 },
 	{ "all-configs",	no_argument,		0,	'a' },
 	{ 0, 0, 0, 0 }
     };
@@ -386,6 +388,7 @@ command_list(ProxySnappers* snappers, ProxySnapper*)
 
     ListMode list_mode = LM_ALL;
     bool show_used_space = true;
+    bool update_used_space = true;
 
     GetOpts::parsed_opts::const_iterator opt;
 
@@ -407,6 +410,11 @@ command_list(ProxySnappers* snappers, ProxySnapper*)
     if ((opt = opts.find("disable-used-space")) != opts.end())
     {
        show_used_space = false;
+    }
+
+    if ((opt = opts.find("no-used-space-update")) != opts.end())
+    {
+       update_used_space = false;
     }
 
     vector<string> tmp;
@@ -435,13 +443,13 @@ command_list(ProxySnappers* snappers, ProxySnapper*)
                  << snapper->getConfig().getSubvolume() << endl;
         }
 
-        list_from_one_config(snapper, list_mode, show_used_space);
+        list_from_one_config(snapper, list_mode, show_used_space, update_used_space);
     }
 }
 
 
 void
-list_from_one_config(ProxySnapper* snapper, ListMode list_mode, bool show_used_space)
+list_from_one_config(ProxySnapper* snapper, ListMode list_mode, bool show_used_space, bool update_used_space)
 {
     const ProxySnapshots& snapshots = snapper->getSnapshots();
 
@@ -473,7 +481,7 @@ list_from_one_config(ProxySnapper* snapper, ListMode list_mode, bool show_used_s
     if (list_mode != LM_ALL && list_mode != LM_SINGLE)
 	show_used_space = false;
 
-    if (show_used_space)
+    if (show_used_space && update_used_space)
     {
 	try
 	{

--- a/doc/snapper.xml.in
+++ b/doc/snapper.xml.in
@@ -356,6 +356,12 @@
 		this option can speedup the listing.</para>
 	      </listitem>
 	    </varlistentry>
+            <varlistentry>
+              <term><option>--no-used-space-update</option></term>
+              <listitem>
+                <para>Do not update used space information.</para>
+              </listitem>
+            </varlistentry>
 	    <varlistentry>
 	      <term><option>-a, --all-configs</option></term>
 	      <listitem>

--- a/server/Client.h
+++ b/server/Client.h
@@ -111,6 +111,7 @@ public:
     void create_comparison(DBus::Connection& conn, DBus::Message& msg);
     void delete_comparison(DBus::Connection& conn, DBus::Message& msg);
     void get_files(DBus::Connection& conn, DBus::Message& msg);
+    void is_quota_enabled(DBus::Connection& conn, DBus::Message& msg);
     void setup_quota(DBus::Connection& conn, DBus::Message& msg);
     void prepare_quota(DBus::Connection& conn, DBus::Message& msg);
     void query_quota(DBus::Connection& conn, DBus::Message& msg);

--- a/snapper/Btrfs.cc
+++ b/snapper/Btrfs.cc
@@ -461,6 +461,17 @@ namespace snapper
     {
     }
 
+    bool
+    Btrfs::isQuotaEnabled() const
+    {
+#ifdef ENABLE_BTRFS_QUOTA
+	SDir subvolume_dir = openSubvolumeDir();
+	return is_quota_enabled(subvolume_dir.fd());
+#else
+	return false;
+#endif
+    }
+
 
     bool
     Btrfs::isSnapshotReadOnly(unsigned int num) const

--- a/snapper/Btrfs.h
+++ b/snapper/Btrfs.h
@@ -76,6 +76,8 @@ namespace snapper
 	virtual void mountSnapshot(unsigned int num) const;
 	virtual void umountSnapshot(unsigned int num) const;
 
+	virtual bool isQuotaEnabled() const;
+
 	virtual bool isSnapshotReadOnly(unsigned int num) const;
 
 	virtual bool checkSnapshot(unsigned int num) const;

--- a/snapper/BtrfsUtils.cc
+++ b/snapper/BtrfsUtils.cc
@@ -614,6 +614,26 @@ namespace snapper
 	    return qgroup_usage;
 	}
 
+	bool is_quota_enabled(int fd)
+	{
+	    struct btrfs_ioctl_search_args args;
+	    struct btrfs_ioctl_search_key *sk = &args.key;
+	    sk->tree_id = BTRFS_ROOT_TREE_OBJECTID;
+	    sk->min_objectid =  sk->max_objectid = BTRFS_QUOTA_TREE_OBJECTID;
+	    sk->min_offset = 0;
+	    sk->max_offset = (u64)(-1);
+	    sk->min_transid = 0;
+	    sk->max_transid = (u64)(-1);
+	    sk->min_type = sk->max_type = BTRFS_ROOT_ITEM_KEY;
+	    sk->nr_items = 4096;
+
+	    if (ioctl(fd, BTRFS_IOC_TREE_SEARCH, &args) < 0) {
+            throw runtime_error_with_errno("ioctl(BTRFS_IOC_TREE_SEARCH) failed", errno);
+	    }
+
+	    return sk->nr_items != 0;
+	}
+
 #endif
 
 

--- a/snapper/BtrfsUtils.h
+++ b/snapper/BtrfsUtils.h
@@ -61,6 +61,7 @@ namespace snapper
 	string get_subvolume(int fd, subvolid_t id);
 	subvolid_t get_id(int fd);
 
+	bool is_quota_enabled(int fd);
 	void quota_enable(int fd);
 	void quota_disable(int fd);
 

--- a/snapper/Ext4.cc
+++ b/snapper/Ext4.cc
@@ -240,6 +240,11 @@ namespace snapper
 	rmdir(snapshotDir(num).c_str());
     }
 
+    bool
+    Ext4::isQuotaEnabled() const
+    {
+	return false;
+    }
 
     bool
     Ext4::isSnapshotReadOnly(unsigned int num) const

--- a/snapper/Ext4.h
+++ b/snapper/Ext4.h
@@ -57,6 +57,8 @@ namespace snapper
 	virtual bool isSnapshotMounted(unsigned int num) const;
 	virtual void mountSnapshot(unsigned int num) const;
 	virtual void umountSnapshot(unsigned int num) const;
+	
+	virtual bool isQuotaEnabled() const;
 
 	virtual bool isSnapshotReadOnly(unsigned int num) const;
 

--- a/snapper/Filesystem.h
+++ b/snapper/Filesystem.h
@@ -77,6 +77,8 @@ namespace snapper
 	virtual void mountSnapshot(unsigned int num) const = 0;
 	virtual void umountSnapshot(unsigned int num) const = 0;
 
+	virtual bool isQuotaEnabled() const = 0;
+
 	virtual bool isSnapshotReadOnly(unsigned int num) const = 0;
 
 	virtual bool checkSnapshot(unsigned int num) const = 0;

--- a/snapper/Lvm.cc
+++ b/snapper/Lvm.cc
@@ -367,6 +367,12 @@ namespace snapper
 	}
     }
 
+    bool
+    Lvm::isQuotaEnabled() const
+    {
+	return false;
+    }
+
 
     bool
     Lvm::isSnapshotReadOnly(unsigned int num) const

--- a/snapper/Lvm.h
+++ b/snapper/Lvm.h
@@ -104,6 +104,8 @@ namespace snapper
 	virtual void mountSnapshot(unsigned int num) const;
 	virtual void umountSnapshot(unsigned int num) const;
 
+	virtual bool isQuotaEnabled() const;
+
 	virtual bool isSnapshotReadOnly(unsigned int num) const;
 
 	virtual bool checkSnapshot(unsigned int num) const;

--- a/snapper/Snapper.cc
+++ b/snapper/Snapper.cc
@@ -655,6 +655,11 @@ namespace snapper
 	    SN_THROW(AclException());
     }
 
+    bool
+    Snapper::isQuotaEnabled() const
+    {
+	return getFilesystem()->isQuotaEnabled();
+    }
 
     void
     Snapper::setupQuota()

--- a/snapper/Snapper.h
+++ b/snapper/Snapper.h
@@ -171,6 +171,8 @@ namespace snapper
 
 	void syncFilesystem() const;
 
+	bool isQuotaEnabled() const;
+
 	void setupQuota();
 
 	void prepareQuota() const;


### PR DESCRIPTION
Currently listing snapshots of a config with sizes involves complete qgroup rescan of the underlying btrfs file system. This means that listing multiple configs from the same file system, the same file system is rescanned several times.

I've added an option to the `list` command to skip this explicit rescanning. So the listing is faster, but might show outdated information.

As a next step I thought that instead of requesting the rescans individually for each config, it would be better to request rescan for a list of configs and the processing side should ensure that each involved btrfs file system is rescanned exactly once. Any ideas/comments?