### PR TITLE
- fixed stringerror function

### DIFF
--- a/snapper/AppUtil.cc
+++ b/snapper/AppUtil.cc
@@ -223,14 +223,14 @@ namespace snapper
     string
     stringerror(int errnum)
     {
-#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE
+#if (_POSIX_C_SOURCE >= 200112L) && ! _GNU_SOURCE
 	char buf1[100];
-	if (strerror_r(errno, buf1, sizeof(buf1)-1) == 0)
+	if (strerror_r(errnum, buf1, sizeof(buf1) - 1) == 0)
 	    return string(buf1);
 	return string("strerror failed");
 #else
 	char buf1[100];
-	const char* buf2 = strerror_r(errno, buf1, sizeof(buf1)-1);
+	const char* buf2 = strerror_r(errnum, buf1, sizeof(buf1) - 1);
 	return string(buf2);
 #endif
     }


### PR DESCRIPTION
The test macro is provided like that in strerror(3) this way now. In older versions it was different.