### PR TITLE
Fix regexp to detect 1-char volume group name.

### DIFF
--- a/snapper/Lvm.cc
+++ b/snapper/Lvm.cc
@@ -387,7 +387,7 @@ namespace snapper
     bool
     Lvm::detectThinVolumeNames(const MtabData& mtab_data)
     {
-	Regex rx("^/dev/mapper/(.+[^-])-([^-].+)$");
+	Regex rx("^/dev/mapper/([^-]+)-([^-].+)$");
 	if (!rx.match(mtab_data.device))
 	{
 	    y2err("could not detect lvm names from '" << mtab_data.device << "'");


### PR DESCRIPTION
I got `Creating config failed (invalid filesystem type).` error when doing `create-config`.

It seems to be caused by my 1-char (`D`) volume group (that results in `/dev/mapper/D-thin` thin volume and `/dev/mapper/D-docker` provisioned volume).

My fix below assume volume group name will not start in `-` (and not include `-`).