### PR TITLE
Fix data corruption leading to kernel panic.

### DIFF
--- a/snapper/BtrfsUtils.cc
+++ b/snapper/BtrfsUtils.cc
@@ -143,10 +143,11 @@ namespace snapper
 
 #ifdef ENABLE_BTRFS_QUOTA
 
+	    size_t size = sizeof(btrfs_qgroup_inherit) + sizeof(((btrfs_qgroup_inherit*) 0)->qgroups[0]);
+	    vector<char> buffer(size, 0);
+        
 	    if (qgroup != no_qgroup)
 	    {
-		size_t size = sizeof(btrfs_qgroup_inherit) + sizeof(((btrfs_qgroup_inherit*) 0)->qgroups[0]);
-		vector<char> buffer(size, 0);
 		struct btrfs_qgroup_inherit* inherit = (btrfs_qgroup_inherit*) &buffer[0];
 
 		inherit->num_qgroups = 1;


### PR DESCRIPTION
I found that trying to use Snapper to create a Btrfs snapshot with a qgroup set causes the system to lock up, sometimes with a kernel panic message on the console. I tracked down the problem to this code. As it currently stands, `buffer` goes out of scope before the `ioctl` call can use it, and in my case, at least, it seems some of the data is already overwritten. Moving it out of the `if` statement lets this work properly.