### PR TITLE
- avoid deadlock for special btrfs directory comparison (bsc#1049574)

### DIFF
--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 18 10:45:54 CET 2019 - aschnell@suse.com
+
+- avoid deadlock for special btrfs directory comparison
+  (bsc#1049574)
+
+-------------------------------------------------------------------
 Wed Nov 21 18:59:09 CET 2018 - gergo@borus.hu
 
 - validate snapshot id corresponding to the default subvolume


### PR DESCRIPTION
For https://trello.com/c/9qmTx4Hu/546-leap-422-1049574-p2-snapper-is-blocked-for-7-days-not-cleaning-up-snapshots-manual-clean-blocked.

The problem is explained in https://bugzilla.suse.com/show_bug.cgi?id=1049574#c26.