### PR TITLE
Revert "- removed unused variable" to fix build on Fedora

### DIFF
--- a/snapper/Lvm.cc
+++ b/snapper/Lvm.cc
@@ -63,7 +63,7 @@ namespace snapper
     Lvm::Lvm(const string& subvolume, const string& root_prefix, const string& mount_type)
 	: Filesystem(subvolume, root_prefix), mount_type(mount_type),
 	  caps(LvmCapabilities::get_lvm_capabilities()),
-	  cache(LvmCache::get_lvm_cache())
+	  cache(LvmCache::get_lvm_cache()), sh(NULL)
     {
 	if (access(LVCREATEBIN, X_OK) != 0)
 	{

--- a/snapper/Lvm.h
+++ b/snapper/Lvm.h
@@ -115,6 +115,7 @@ namespace snapper
 	const string mount_type;
 	const LvmCapabilities* caps;
 	LvmCache* cache;
+	SelinuxLabelHandle* sh;
 
 	bool detectThinVolumeNames(const MtabData& mtab_data);
 	void activateSnapshot(const string& vg_name, const string& lv_name) const;


### PR DESCRIPTION
The variable previously removed is actually used when SELinux is enabled.

This reverts commit 842721cd470ce5b97316fff250b0c1fa356a00f4.