### PR TITLE
- added Ubuntu 19.04

### DIFF
--- a/Dockerfile.leap
+++ b/Dockerfile.leap
@@ -1,4 +1,4 @@
-# Build the latest openSUSE Leap (42.x) image
+# Build the latest openSUSE Leap image
 FROM opensuse/leap
 
 RUN zypper --non-interactive in --no-recommends \

--- a/Dockerfile.leap
+++ b/Dockerfile.leap
@@ -4,13 +4,15 @@ FROM opensuse/leap
 RUN zypper --non-interactive in --no-recommends \
   autoconf \
   automake \
-  boost-devel \
   dbus-1-devel \
   docbook-xsl-stylesheets \
   e2fsprogs-devel \
   gcc-c++ \
   grep \
   libacl-devel \
+  libboost_system-devel \
+  libboost_test-devel \
+  libboost_thread-devel \
   libbtrfs-devel \
   libmount-devel \
   libtool \

--- a/Dockerfile.leap
+++ b/Dockerfile.leap
@@ -1,5 +1,5 @@
 # Build the latest openSUSE Leap (42.x) image
-FROM opensuse:leap
+FROM opensuse/leap
 
 RUN zypper --non-interactive in --no-recommends \
   autoconf \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,5 +1,5 @@
-# Build Ubuntu 17.10 image
-FROM ubuntu:17.10
+# Build Ubuntu 18.10 image
+FROM ubuntu:18.10
 
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/run
 RUN apt-get update && \

--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,8 @@ UBUNTU_FLAVOURS =	\
     xUbuntu_17.04	\
     xUbuntu_17.10	\
     xUbuntu_18.04	\
-    xUbuntu_18.10
+    xUbuntu_18.10	\
+    xUbuntu_19.04
 
 show-debian:
 	@echo "Debian flavors: $(DEBIAN_FLAVOURS)"


### PR DESCRIPTION
Enable building for Ubuntu 19.04 in https://build.opensuse.org/package/show/filesystems:snapper/snapper.

Also address the Travis failures mentioned in PR #484.