### PR TITLE
- use Ubuntu 18.10 in Travis

### DIFF
--- a/Dockerfile.leap
+++ b/Dockerfile.leap
@@ -1,5 +1,5 @@
-# Build the latest openSUSE Leap (42.x) image
-FROM opensuse:leap
+# Build the latest openSUSE Leap image
+FROM opensuse/leap
 
 RUN zypper --non-interactive in --no-recommends \
   autoconf \

--- a/Dockerfile.leap
+++ b/Dockerfile.leap
@@ -4,13 +4,15 @@ FROM opensuse/leap
 RUN zypper --non-interactive in --no-recommends \
   autoconf \
   automake \
-  boost-devel \
   dbus-1-devel \
   docbook-xsl-stylesheets \
   e2fsprogs-devel \
   gcc-c++ \
   grep \
   libacl-devel \
+  libboost_system-devel \
+  libboost_test-devel \
+  libboost_thread-devel \
   libbtrfs-devel \
   libmount-devel \
   libtool \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,5 +1,5 @@
-# Build Ubuntu 16.10 image
-FROM ubuntu:17.10
+# Build Ubuntu 18.10 image
+FROM ubuntu:18.10
 
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/run
 RUN apt-get update && \


### PR DESCRIPTION
The old one, Ubuntu 17.10, fails in Travis. Also applies to master.