### PR TITLE
Add option to reuse existing subvolume

### DIFF
--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -390,7 +390,6 @@ doit()
     mnt_table_parse_mtab(mtab_table, NULL);
 
     libmnt_fs* expected_fs = create_fstab_line(fs, subvol_option, subvolume_name);
-    char* expected_target = mnt_fs_get_target(expected_fs);
 
     // Consistency checks on (partially) existing entries
     libmnt_fs* fstab_entry = mnt_table.find_target(target, MNT_ITER_FORWARD);

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -322,7 +322,13 @@ doit()
 	throw runtime_error("invalid target");
 
     if (access(target.c_str(), F_OK) == 0)
-	throw runtime_error("target exists");
+    {
+	struct stat sb;
+	if (force && lstat(target.c_str(), &sb) == 0 && sb.st_mode & S_IFDIR)
+	    cout << "reusing target dir" << endl;
+	else
+	    throw runtime_error("target exists");
+    }
 
     if (access(dirname(target).c_str(), F_OK) != 0)
 	throw runtime_error("parent of target does not exist");

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -335,6 +335,8 @@ do_consistency_checks(MntTable& mnt_table, libmnt_fs* fs, libmnt_fs* expected_fs
 		throw runtime_error("subvolume of mounted target doesn't match");
 	}
     }
+
+    mnt_unref_cache(cache);
 }
 
 

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -186,13 +186,10 @@ do_add_fstab_and_mount(MntTable& mnt_table, const libmnt_fs* fs, const string& s
 
 
 void
-do_set_nocow()
+do_set_cow_flag()
 {
-    if (!set_nocow)
-	return;
-
     if (verbose)
-	cout << "do-set-nocow" << endl;
+	cout << "do-set-cow-flag" << endl;
 
     int fd = open(target.c_str(), O_RDONLY);
     if (fd == -1)
@@ -208,7 +205,10 @@ do_set_nocow()
 	throw runtime_error_with_errno("ioctl(EXT2_IOC_GETFLAGS) failed", errno);
     }
 
-    flags |= FS_NOCOW_FL;
+    if (set_nocow)
+	flags |= FS_NOCOW_FL;
+    else
+	flags &= ~FS_NOCOW_FL;
 
     if (ioctl(fd, EXT2_IOC_SETFLAGS, &flags) == -1)
     {
@@ -413,7 +413,7 @@ doit()
 
     do_add_fstab_and_mount(mnt_table, fs, subvol_option, subvolume_name);
 
-    do_set_nocow();
+    do_set_cow_flag();
 }
 
 

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -270,7 +270,7 @@ find_filesystem(MntTable& mnt_table)
 struct TmpMountpoint {
     unique_ptr<char[]> mountpoint;
     const libmnt_fs* fs;
-    TmpMountpoint(const string tmpMountpoint, const libmnt_fs* libmntfs, const string& subvol_opts)
+    TmpMountpoint(const string& tmpMountpoint, const libmnt_fs* libmntfs, const string& subvol_opts)
 	: mountpoint(strdup(tmpMountpoint.c_str())), fs(libmntfs)
     {
 	if (!mkdtemp(mountpoint.get()))
@@ -376,8 +376,8 @@ doit()
     }
     catch (const runtime_error_with_errno& e)
     {
-	if (e.error_number == EEXIST)
-	    cout << "subvolume exists already" << endl;
+	if (e.error_number == EEXIST && force)
+	    cout << "subvolume exists already, reusing" << endl;
 	else
 	    throw;
     }

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -227,16 +227,12 @@ do_set_cow_flag()
 
 
 bool
-is_subvol_mount(const string& fs_options)
+is_subvol_mount(libmnt_fs* fs)
 {
-    vector<string> tmp1;
-    boost::split(tmp1, fs_options, boost::is_any_of(","), boost::token_compress_on);
-    for (const string& tmp2 : tmp1)
-    {
-	if (boost::starts_with(tmp2, "subvol=") || boost::starts_with(tmp2, "subvolid="))
-	    return true;
-    }
-
+    if (mnt_fs_get_option(fs, "subvol", NULL, NULL) == 0)
+	return true;
+    if (mnt_fs_get_option(fs, "subvolid", NULL, NULL) == 0)
+	return true;
     return false;
 }
 
@@ -268,7 +264,7 @@ find_filesystem(MntTable& mnt_table)
 	if (fs_fstype != "btrfs")
 	    throw runtime_error("filesystem is not btrfs");
 
-	if (!is_subvol_mount(fs_options))
+	if (!is_subvol_mount(fs))
 	    return fs;
 
 	if (verbose)

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -377,7 +377,14 @@ doit()
     catch (const runtime_error_with_errno& e)
     {
 	if (e.error_number == EEXIST && force)
+	{
+	    const string path = string(tmp_mountpoint.mountpoint.get()).append("/").append(subvolume_name);
+
+	    struct stat sb;
+	    if (stat(path.c_str(), &sb) == 0 && !is_subvolume(sb))
+		throw runtime_error_with_errno("path exists, but isn't a subvolume", e.error_number);
 	    cout << "subvolume exists already, reusing" << endl;
+	}
 	else
 	    throw;
     }

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -379,9 +379,13 @@ doit()
     // Determine name for new subvolume: It is the target name without the
     // leading filesystem target.
 
-    string subvolume_name = target.substr(fs_target.size() + (fs_target == "/" ? 0 : 1));
+    string subvolume_name = target.substr(fs_target.size() +
+					 (fs_target == "/" || fs_target == target ? 0 : 1));
     if (verbose)
 	cout << "subvolume-name:" << subvolume_name << endl;
+
+    if (subvolume_name.empty())
+	throw runtime_error("target is a dedicated mountpoint");
 
     // Execute all steps.
 

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -378,12 +378,13 @@ doit()
     {
 	if (e.error_number == EEXIST && force)
 	{
-	    const string path = string(tmp_mountpoint.mountpoint.get()).append("/").append(subvolume_name);
-
+	    const string path = string(tmp_mountpoint.mountpoint.get()) + "/" + subvolume_name;
 	    struct stat sb;
-	    if (stat(path.c_str(), &sb) == 0 && !is_subvolume(sb))
-		throw runtime_error_with_errno("path exists, but isn't a subvolume", e.error_number);
-	    cout << "subvolume exists already, reusing" << endl;
+
+	    if (lstat(path.c_str(), &sb) == 0 && is_subvolume(sb))
+		cout << "subvolume exists already, reusing" << endl;
+	    else
+		throw runtime_error_with_errno("cannot reuse path as subvolume", e.error_number);
 	}
 	else
 	    throw;

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -418,8 +418,12 @@ doit()
 						      MNT_ITER_BACKWARD);
     if (subvolume_name.empty())
 	throw runtime_error("target is a dedicated mountpoint");
+    // Map UUID / LABEL to a physical device name
+    const char* real_device = mnt_resolve_spec(mnt_fs_get_source(expected_fs), cache);
+    if (real_device == NULL)
+	throw runtime_error("parent volume in fstab does not match expected device");
     if (fstab_entry != NULL && strcmp(mnt_resolve_spec(mnt_fs_get_source(fstab_entry), cache),
-				      mnt_resolve_spec(mnt_fs_get_source(expected_fs), cache)) != 0)
+				      real_device) != 0)
 	throw runtime_error("existing fstab entry doesn't match target device");
     if (fstab_entry != NULL)
     {
@@ -431,8 +435,6 @@ doit()
     // Something is mounted there already. Is it the correct device?
     if (mounted_entry != NULL)
     {
-	// Map UUID / LABEL to a physical device name
-	const char* real_device = mnt_resolve_spec(mnt_fs_get_source(expected_fs), cache);
 	// Find last device in mtab to get the actual mount
 	mounted_entry = mtab_table.find_target(mnt_fs_get_target(expected_fs), MNT_ITER_BACKWARD);
 	if (mounted_entry != NULL)

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -140,6 +140,21 @@ do_add_fstab_and_mount(MntTable& mnt_table, const libmnt_fs* fs, const string& s
     if (!x)
 	throw runtime_error("mnt_copy_fs failed");
 
+    if (force)
+    {
+	struct libmnt_context* cxt = mnt_new_context();
+	libmnt_fs* y;
+	mnt_context_set_fs(cxt, x);
+	mnt_context_set_target(cxt, target.c_str());
+	if (!mnt_context_find_umount_fs(cxt, target.c_str(), &y))
+	{
+	    cout << "target mounted - umounting" << endl;
+	    int ret = mnt_context_umount(cxt);
+	    if (ret != 0)
+		throw runtime_error(sformat("mnt_context_umount failed, ret:%d", errno));
+	}
+    }
+
     mnt_fs_set_target(x, target.c_str());
 
     string full_subvol_option = subvolume_name;
@@ -252,7 +267,19 @@ find_filesystem(MntTable& mnt_table)
 	    throw runtime_error("filesystem is not btrfs");
 
 	if (fs_target == target)
-	    throw runtime_error("target exists in fstab");
+	{
+	    if (force)
+	    {
+		libmnt_fs* fs = mnt_table.find_target(target.c_str(), MNT_ITER_FORWARD);
+	        if (fs != NULL)
+		{
+		    cout << "removing existing fstab entry" << endl;
+		    mnt_table.remove_fs(fs);
+		}
+	    }
+	    else
+		throw runtime_error("target exists in fstab");
+	}
 
 	if (!is_subvol_mount(fs_options))
 	    return fs;

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -287,9 +287,11 @@ get_abs_subvol_path(string subvolume)
 }
 
 
-struct TmpMountpoint {
+class TmpMountpoint {
     unique_ptr<char[]> mountpoint;
     const libmnt_fs* fs;
+
+public:
     TmpMountpoint(const string& tmpMountpoint, const libmnt_fs* libmntfs, const string& subvol_opts)
 	: mountpoint(strdup(tmpMountpoint.c_str())), fs(libmntfs)
     {
@@ -311,6 +313,12 @@ struct TmpMountpoint {
     {
 	do_tmp_umount(fs, mountpoint.get());
 	rmdir(mountpoint.get());
+    }
+
+    string
+    get_path()
+    {
+	return mountpoint.get();
     }
 };
 
@@ -445,13 +453,13 @@ doit()
 
     try
     {
-	do_create_subvolume(tmp_mountpoint.mountpoint.get(), subvolume_name);
+	do_create_subvolume(tmp_mountpoint.get_path(), subvolume_name);
     }
     catch (const runtime_error_with_errno& e)
     {
 	if (e.error_number == EEXIST)
 	{
-	    const string path = string(tmp_mountpoint.mountpoint.get()) + "/" + subvolume_name;
+	    const string path = string(tmp_mountpoint.get_path()) + "/" + subvolume_name;
 	    struct stat sb;
 
 	    if (lstat(path.c_str(), &sb) == 0 && is_subvolume(sb))

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -290,15 +290,13 @@ get_abs_subvol_path(string subvolume)
 void
 do_consistency_checks(MntTable& mnt_table, libmnt_fs* fs, libmnt_fs* expected_fs)
 {
-    char *subvol_expected, *subvol_fstab, *subvol_real;
-    const char *dev_expected, *dev_fstab;
-
     // Set up cache for UUID / LABEL resolution in mnt_table_find_source
     libmnt_cache* cache = mnt_new_cache();
     MntTable mtab_table("/");
     mtab_table.set_cache(cache);
     mtab_table.parse_mtab();
 
+    char* subvol_expected;
     if (mnt_fs_get_option(expected_fs, "subvol", &subvol_expected, NULL) != 0)
 	throw runtime_error("mnt_fs_get_option failed");
 
@@ -307,8 +305,8 @@ do_consistency_checks(MntTable& mnt_table, libmnt_fs* fs, libmnt_fs* expected_fs
     libmnt_fs* mounted_entry = mtab_table.find_target(mnt_fs_get_target(expected_fs),
 						      MNT_ITER_BACKWARD);
     // Map UUID / LABEL to a physical device name
-    dev_expected = mnt_resolve_spec(mnt_fs_get_source(expected_fs), cache);
-    dev_fstab = mnt_resolve_spec(mnt_fs_get_source(fstab_entry), cache);
+    const char* dev_expected = mnt_resolve_spec(mnt_fs_get_source(expected_fs), cache);
+    const char* dev_fstab = mnt_resolve_spec(mnt_fs_get_source(fstab_entry), cache);
     if (dev_expected == NULL)
 	throw runtime_error("parent volume in fstab does not match expected device");
     if (fstab_entry != NULL && dev_fstab == NULL)
@@ -317,23 +315,32 @@ do_consistency_checks(MntTable& mnt_table, libmnt_fs* fs, libmnt_fs* expected_fs
 	throw runtime_error("existing fstab entry doesn't match target device");
     if (fstab_entry != NULL)
     {
+	char* subvol_fstab;
 	if (mnt_fs_get_option(fstab_entry, "subvol", &subvol_fstab, NULL) != 0 ||
 		get_abs_subvol_path(subvol_fstab) != get_abs_subvol_path(subvol_expected))
 	    throw runtime_error("existing fstab entry's subvolume doesn't match");
     }
+
     // Something is mounted there already. Is it the correct device?
     if (mounted_entry != NULL)
     {
-	// Find last device in mtab to get the actual mount
-	mounted_entry = mtab_table.find_target(mnt_fs_get_target(expected_fs), MNT_ITER_BACKWARD);
-	if (mounted_entry != NULL)
+	if (strcmp(dev_expected, mnt_fs_get_source(mounted_entry)) != 0)
 	{
-	    if (strcmp(dev_expected, mnt_fs_get_source(mounted_entry)) != 0)
+	    // In case of multi device btrfs the device name can differ, so compare the UUIDs.
+	    const char* uuid_expected = mnt_cache_find_tag_value(cache, dev_expected, "UUID");
+	    const char* uuid_mounted = mnt_cache_find_tag_value(cache, mnt_fs_get_source(mounted_entry), "UUID");
+
+	    if (!uuid_expected || !uuid_mounted)
+		throw runtime_error("failed to get uuid");
+
+	    if (strcmp(uuid_expected, uuid_mounted) != 0)
 		throw runtime_error("different device mounted on target");
-	    if (mnt_fs_get_option(mounted_entry, "subvol", &subvol_real, NULL) != 0 ||
-		    get_abs_subvol_path(subvol_expected) != get_abs_subvol_path(subvol_real))
-		throw runtime_error("subvolume of mounted target doesn't match");
 	}
+
+	char* subvol_real;
+	if (mnt_fs_get_option(mounted_entry, "subvol", &subvol_real, NULL) != 0 ||
+	    get_abs_subvol_path(subvol_expected) != get_abs_subvol_path(subvol_real))
+	    throw runtime_error("subvolume of mounted target doesn't match");
     }
 
     mnt_unref_cache(cache);

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -418,7 +418,8 @@ doit()
 						     MNT_ITER_BACKWARD);
     if (subvolume_name.empty())
 	throw runtime_error("target is a dedicated mountpoint");
-    if (fstab_entry != NULL && strcmp(mnt_fs_get_source(fstab_entry), mnt_fs_get_source(expected_fs)) != 0)
+    if (fstab_entry != NULL && strcmp(mnt_resolve_spec(mnt_fs_get_source(fstab_entry), cache),
+				      mnt_resolve_spec(mnt_fs_get_source(expected_fs), cache)) != 0)
 	throw runtime_error("existing fstab entry doesn't match target device");
     if (fstab_entry != NULL)
     {
@@ -431,8 +432,7 @@ doit()
     if (mounted_entry != NULL)
     {
 	// Map UUID / LABEL to a physical device name
-	const char* real_device = mnt_fs_get_source(mnt_table_find_source(mtab_table,
-							mnt_fs_get_source(expected_fs), MNT_ITER_BACKWARD));
+	const char* real_device = mnt_resolve_spec(mnt_fs_get_source(expected_fs), cache);
 	// Find last device in mtab to get the actual mount
 	mounted_entry = mnt_table_find_target(mtab_table, mnt_fs_get_target(expected_fs),
 					      MNT_ITER_BACKWARD);

--- a/client/mksubvolume.cc
+++ b/client/mksubvolume.cc
@@ -315,7 +315,7 @@ public:
 	rmdir(mountpoint.get());
     }
 
-    string
+    const string
     get_path()
     {
 	return mountpoint.get();
@@ -459,7 +459,7 @@ doit()
     {
 	if (e.error_number == EEXIST)
 	{
-	    const string path = string(tmp_mountpoint.get_path()) + "/" + subvolume_name;
+	    const string path = tmp_mountpoint.get_path() + "/" + subvolume_name;
 	    struct stat sb;
 
 	    if (lstat(path.c_str(), &sb) == 0 && is_subvolume(sb))

--- a/doc/mksubvolume.xml.in
+++ b/doc/mksubvolume.xml.in
@@ -21,7 +21,6 @@
   <refsynopsisdiv id='synopsis'>
     <cmdsynopsis>
       <command>mksubvolume</command>
-      <arg choice='opt'>--force</arg>
       <arg choice='opt'>--nocow</arg>
       <arg choice='opt'>--verbose</arg>
       <arg choice='req'><replaceable>path</replaceable></arg>
@@ -38,13 +37,6 @@
   <refsect1 id='global_options'>
     <title>OPTIONS</title>
     <variablelist>
-      <varlistentry>
-	<term><option>-f, --force</option></term>
-	<listitem>
-	  <para>Ignore if subvolume or target directory already exist - reuse
-	  them and proceed.</para>
-	</listitem>
-      </varlistentry>
       <varlistentry>
 	<term><option>--nocow</option></term>
 	<listitem>

--- a/doc/mksubvolume.xml.in
+++ b/doc/mksubvolume.xml.in
@@ -21,6 +21,7 @@
   <refsynopsisdiv id='synopsis'>
     <cmdsynopsis>
       <command>mksubvolume</command>
+      <arg choice='opt'>--force</arg>
       <arg choice='opt'>--nocow</arg>
       <arg choice='opt'>--verbose</arg>
       <arg choice='req'><replaceable>path</replaceable></arg>
@@ -37,6 +38,13 @@
   <refsect1 id='global_options'>
     <title>OPTIONS</title>
     <variablelist>
+      <varlistentry>
+	<term><option>-f, --force</option></term>
+	<listitem>
+	  <para>Ignore if subvolume already exists - reuse it and
+	  proceed.</para>
+	</listitem>
+      </varlistentry>
       <varlistentry>
 	<term><option>--nocow</option></term>
 	<listitem>

--- a/doc/mksubvolume.xml.in
+++ b/doc/mksubvolume.xml.in
@@ -41,8 +41,8 @@
       <varlistentry>
 	<term><option>-f, --force</option></term>
 	<listitem>
-	  <para>Ignore if subvolume already exists - reuse it and
-	  proceed.</para>
+	  <para>Ignore if subvolume or target directory already exist - reuse
+	  them and proceed.</para>
 	</listitem>
       </varlistentry>
       <varlistentry>

--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug 30 17:29:34 CET 2019 - iforster@suse.com
+
+- reusing existing subvolumes on mksubvolume run
+  (bsc#1138725, bsc#1126900, gh#openSUSE/snapper#236)
+
+-------------------------------------------------------------------
 Tue Mar 26 10:15:55 CET 2019 - aschnell@suse.com
 
 - fixed seg.fault during rollback if the previous default subvolume

--- a/snapper/MntTable.h
+++ b/snapper/MntTable.h
@@ -61,6 +61,18 @@ namespace snapper
 		throw runtime_error("mnt_table_parse_fstab failed");
 	}
 
+	void parse_mtab()
+	{
+	    if (mnt_table_parse_mtab(table, NULL))
+		throw runtime_error("mnt_table_parse_mtab failed");
+	}
+
+	void set_cache(libmnt_cache* cache)
+	{
+	    if (cache == NULL || mnt_table_set_cache(table, cache) != 0)
+		throw runtime_error("Setting the file system cache failed");
+	}
+
 	void replace_file()
 	{
 	    if (mnt_table_replace_file(table, target_fstab().c_str()) != 0)

--- a/snapper/MntTable.h
+++ b/snapper/MntTable.h
@@ -52,9 +52,7 @@ namespace snapper
 
 	~MntTable()
 	{
-	    mnt_reset_table(table);
-	    if (cachep)
-		mnt_unref_cache(cachep);
+	    mnt_unref_table(table);
 	}
 
 	void parse_fstab()
@@ -73,7 +71,6 @@ namespace snapper
 	{
 	    if (cache == NULL || mnt_table_set_cache(table, cache) != 0)
 		throw runtime_error("Setting the file system cache failed");
-	    cachep = cache;
 	}
 
 	void replace_file()
@@ -111,8 +108,6 @@ namespace snapper
 	const string root_prefix;
 
 	struct libmnt_table* table;
-
-	struct libmnt_cache* cachep;
     };
 
 }

--- a/snapper/MntTable.h
+++ b/snapper/MntTable.h
@@ -53,6 +53,8 @@ namespace snapper
 	~MntTable()
 	{
 	    mnt_reset_table(table);
+	    if (cachep)
+		mnt_unref_cache(cachep);
 	}
 
 	void parse_fstab()
@@ -71,6 +73,7 @@ namespace snapper
 	{
 	    if (cache == NULL || mnt_table_set_cache(table, cache) != 0)
 		throw runtime_error("Setting the file system cache failed");
+	    cachep = cache;
 	}
 
 	void replace_file()
@@ -109,6 +112,7 @@ namespace snapper
 
 	struct libmnt_table* table;
 
+	struct libmnt_cache* cachep;
     };
 
 }


### PR DESCRIPTION
If a subvolume exists already mksubvolume will abort. In certain
situations however, e.g. if there was a rollback to a previous snapshot,
it may be desirable to be able to reuse this subvolume.

This will make it possible to use the mksubvolume command in package
scripts.

To avoid having to duplicate the exception handler code multiple times
a C wrapper object was introduced to automatically clean up in the
destructor.

Fixes https://github.com/openSUSE/snapper/issues/236.