### PR TITLE
 Move D-Bus conf file to share/dbus-1/system.d 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,14 @@ if test "x$with_selinux" = "xyes"; then
 	AC_CHECK_LIB(selinux, selinux_snapperd_contexts_path, [], [AC_MSG_ERROR([selinux library does not provide selinux_snapperd_contexts_path symbol])])
 fi
 
+AC_ARG_WITH(dbus-sys, [  --with-dbus-sys=<dir>   where D-BUS system.d directory is])
+if ! test -z "$with_dbus_sys" ; then
+    DBUS_SYS_DIR="$with_dbus_sys"
+else
+    DBUS_SYS_DIR="$datadir/dbus-1/system.d"
+fi
+AC_SUBST(DBUS_SYS_DIR)
+
 PKG_CHECK_MODULES(DBUS, dbus-1)
 
 AC_CHECK_HEADER(acl/libacl.h,[],[AC_MSG_ERROR([Cannout find libacl headers. Please install libacl-devel])])

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -18,7 +18,7 @@ install-data-local:
 	install -D -m 644 lvm.txt $(DESTDIR)/etc/snapper/filters/lvm.txt
 	install -D -m 644 x11.txt $(DESTDIR)/etc/snapper/filters/x11.txt
 
-	install -D -m 644 org.opensuse.Snapper.conf $(DESTDIR)/etc/dbus-1/system.d/org.opensuse.Snapper.conf
+	install -D -m 644 org.opensuse.Snapper.conf $(DESTDIR)/$(DBUS_SYS_DIR)/org.opensuse.Snapper.conf
 	install -D -m 644 org.opensuse.Snapper.service $(DESTDIR)/usr/share/dbus-1/system-services/org.opensuse.Snapper.service
 
 	install -D -m 644 timeline.service $(DESTDIR)/usr/lib/systemd/system/snapper-timeline.service

--- a/dists/debian/snapper.install
+++ b/dists/debian/snapper.install
@@ -1,8 +1,8 @@
 etc/cron.daily/snapper
 etc/cron.hourly/snapper
-etc/dbus-1/system.d/org.opensuse.Snapper.conf
 etc/logrotate.d/snapper
 usr/bin/snapper
 usr/sbin/snapperd
+usr/share/dbus-1/system.d/org.opensuse.Snapper.conf
 usr/share/dbus-1/system-services/org.opensuse.Snapper.service
 usr/share/locale/*/LC_MESSAGES/snapper.mo

--- a/snapper.spec.in
+++ b/snapper.spec.in
@@ -167,7 +167,7 @@ fi
 %endif
 %config(noreplace) %{_sysconfdir}/logrotate.d/snapper
 %{_unitdir}/snapper-*.*
-%config /etc/dbus-1/system.d/org.opensuse.Snapper.conf
+%{_datadir}/dbus-1/system.d/org.opensuse.Snapper.conf
 %{_datadir}/dbus-1/system-services/org.opensuse.Snapper.service
 
 %package -n libsnapper@LIBVERSION_MAJOR@


### PR DESCRIPTION
Since D-Bus 1.9.18 configuration files installed by third-party should
go in share/dbus-1/system.d. The old location is for sysadmin overrides.