### PR TITLE
add description to the second snapshot of rollback

### DIFF
--- a/client/snapper.cc
+++ b/client/snapper.cc
@@ -1110,7 +1110,7 @@ command_rollback(cli::GlobalOptions* global_options, ProxySnappers* snappers, Pr
 	if (!global_options->quiet())
 	    cout << sformat(_("Creating read-write snapshot of snapshot %d."), tmp->getNum()) << flush;
 
-	if (tmp != snapshots.end() && scd2.description == default_description)
+	if (tmp != snapshots.end() && scd2.description == default_description2)
 	    scd2.description += sformat(" of #%d", tmp->getNum());
 
 	scd2.read_only = false;

--- a/client/snapper.cc
+++ b/client/snapper.cc
@@ -1084,9 +1084,9 @@ command_rollback(cli::GlobalOptions* global_options, ProxySnappers* snappers, Pr
 	if (!global_options->quiet())
 	    cout << _("Creating read-write snapshot of current subvolume.") << flush;
 
-    ProxySnapshots::const_iterator active = snapshots.getActive();
-    if (active != snapshots.end() && scd2.description == default_description)
-        scd2.description += sformat(" of #%d", active->getNum());
+	ProxySnapshots::const_iterator active = snapshots.getActive();
+	if (active != snapshots.end() && scd2.description == default_description)
+	    scd2.description += sformat(" of #%d", active->getNum());
 
 	scd2.read_only = false;
 	snapshot2 = snapper->createSingleSnapshot(snapshots.getCurrent(), scd2);
@@ -1109,8 +1109,8 @@ command_rollback(cli::GlobalOptions* global_options, ProxySnappers* snappers, Pr
 	if (!global_options->quiet())
 	    cout << sformat(_("Creating read-write snapshot of snapshot %d."), tmp->getNum()) << flush;
 
-    if (tmp != snapshots.end() && scd2.description == default_description)
-        scd2.description += sformat(" of #%d", tmp->getNum());
+	if (tmp != snapshots.end() && scd2.description == default_description)
+	    scd2.description += sformat(" of #%d", tmp->getNum());
 
 	scd2.read_only = false;
 	snapshot2 = snapper->createSingleSnapshot(tmp, scd2);

--- a/client/snapper.cc
+++ b/client/snapper.cc
@@ -1024,6 +1024,7 @@ command_rollback(cli::GlobalOptions* global_options, ProxySnappers* snappers, Pr
     scd1.userdata["important"] = "yes";
 
     SCD scd2;
+    scd2.description = default_description;
 
     GetOpts::parsed_opts::const_iterator opt;
 
@@ -1065,6 +1066,10 @@ command_rollback(cli::GlobalOptions* global_options, ProxySnappers* snappers, Pr
 
     if (previous_default != snapshots.end() && scd1.description == default_description)
         scd1.description += sformat(" of #%d", previous_default->getNum());
+
+    ProxySnapshots::const_iterator active = snapshots.getActive();
+    if (active != snapshots.end() && scd2.description == default_description)
+        scd2.description += sformat(" of #%d", active->getNum());
 
     ProxySnapshots::const_iterator snapshot1 = snapshots.end();
     ProxySnapshots::const_iterator snapshot2 = snapshots.end();

--- a/client/snapper.cc
+++ b/client/snapper.cc
@@ -1067,10 +1067,6 @@ command_rollback(cli::GlobalOptions* global_options, ProxySnappers* snappers, Pr
     if (previous_default != snapshots.end() && scd1.description == default_description)
         scd1.description += sformat(" of #%d", previous_default->getNum());
 
-    ProxySnapshots::const_iterator active = snapshots.getActive();
-    if (active != snapshots.end() && scd2.description == default_description)
-        scd2.description += sformat(" of #%d", active->getNum());
-
     ProxySnapshots::const_iterator snapshot1 = snapshots.end();
     ProxySnapshots::const_iterator snapshot2 = snapshots.end();
 
@@ -1087,6 +1083,10 @@ command_rollback(cli::GlobalOptions* global_options, ProxySnappers* snappers, Pr
 
 	if (!global_options->quiet())
 	    cout << _("Creating read-write snapshot of current subvolume.") << flush;
+
+    ProxySnapshots::const_iterator active = snapshots.getActive();
+    if (active != snapshots.end() && scd2.description == default_description)
+        scd2.description += sformat(" of #%d", active->getNum());
 
 	scd2.read_only = false;
 	snapshot2 = snapper->createSingleSnapshot(snapshots.getCurrent(), scd2);
@@ -1108,6 +1108,9 @@ command_rollback(cli::GlobalOptions* global_options, ProxySnappers* snappers, Pr
 
 	if (!global_options->quiet())
 	    cout << sformat(_("Creating read-write snapshot of snapshot %d."), tmp->getNum()) << flush;
+
+    if (tmp != snapshots.end() && scd2.description == default_description)
+        scd2.description += sformat(" of #%d", tmp->getNum());
 
 	scd2.read_only = false;
 	snapshot2 = snapper->createSingleSnapshot(tmp, scd2);

--- a/client/snapper.cc
+++ b/client/snapper.cc
@@ -1015,6 +1015,7 @@ command_rollback(cli::GlobalOptions* global_options, ProxySnappers* snappers, Pr
     }
 
     const string default_description = "rollback backup";
+    const string default_description2 = "writable copy";
 
     bool print_number = false;
 
@@ -1024,7 +1025,7 @@ command_rollback(cli::GlobalOptions* global_options, ProxySnappers* snappers, Pr
     scd1.userdata["important"] = "yes";
 
     SCD scd2;
-    scd2.description = default_description;
+    scd2.description = default_description2;
 
     GetOpts::parsed_opts::const_iterator opt;
 
@@ -1085,7 +1086,7 @@ command_rollback(cli::GlobalOptions* global_options, ProxySnappers* snappers, Pr
 	    cout << _("Creating read-write snapshot of current subvolume.") << flush;
 
 	ProxySnapshots::const_iterator active = snapshots.getActive();
-	if (active != snapshots.end() && scd2.description == default_description)
+	if (active != snapshots.end() && scd2.description == default_description2)
 	    scd2.description += sformat(" of #%d", active->getNum());
 
 	scd2.read_only = false;


### PR DESCRIPTION
When we do a rollback, snapper will create two snapshots.
For example, the default subvolume is number 10, the latest is number 15, and the one we want to go back, is number 12.
Rollback will create number 16 from number 10, and number 17 from number 12 as the new writable default.
The first snapshot, number 16 will get the description "rollback backup of #10", but the other one will not get any description. This patch will modify it, to add the description to the second snapshot also, like this: "rollback backup of #12". This way it is easy to identify where the snapshot came from.