### PR TITLE
Work around a bootstrapping problem

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -149,7 +149,7 @@ fi
 PKG_CHECK_MODULES(DBUS, dbus-1)
 PKG_CHECK_MODULES(XML2, libxml-2.0)
 if test "x$with_zypp" = "xyes"; then
-   PKG_CHECK_MODULES(JSONC, json-c)
+   PKG_CHECK_MODULES(JSONC, json-c, [], [AC_MSG_WARN([Cannot find json-c. Please install libjson-c-devel])])
 fi
 
 AC_CHECK_HEADER(acl/libacl.h,[],[AC_MSG_ERROR([Cannout find libacl headers. Please install libacl-devel])])


### PR DESCRIPTION
The authoritative package is made by building with the *previous*
version dependencies, so we can't hard-require a new library.
Make it a warning.

Should fix this failure: https://ci.suse.de/job/snapper-master/716/console