### PR TITLE
- renamed variable for consistency

### DIFF
--- a/client/snapper.cc
+++ b/client/snapper.cc
@@ -1014,13 +1014,13 @@ command_rollback(cli::GlobalOptions* global_options, ProxySnappers* snappers, Pr
 	exit(EXIT_FAILURE);
     }
 
-    const string default_description = "rollback backup";
+    const string default_description1 = "rollback backup";
     const string default_description2 = "writable copy";
 
     bool print_number = false;
 
     SCD scd1;
-    scd1.description = default_description;
+    scd1.description = default_description1;
     scd1.cleanup = "number";
     scd1.userdata["important"] = "yes";
 
@@ -1065,7 +1065,7 @@ command_rollback(cli::GlobalOptions* global_options, ProxySnappers* snappers, Pr
 
     ProxySnapshots::iterator previous_default = snapshots.getDefault();
 
-    if (previous_default != snapshots.end() && scd1.description == default_description)
+    if (previous_default != snapshots.end() && scd1.description == default_description1)
         scd1.description += sformat(" of #%d", previous_default->getNum());
 
     ProxySnapshots::const_iterator snapshot1 = snapshots.end();


### PR DESCRIPTION
Since there is now a variable default_description2 for snapshot 2 during rollback the variable default_description is only used for snapshot 1 and thus has to be named default_description1 for consistency.