### PR TITLE
update translations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - BUILD_FLAVOR=tumbleweed
   - BUILD_FLAVOR=leap
   - BUILD_FLAVOR=fedora DOCKER_TAG=31
-  - BUILD_FLAVOR=ubuntu DOCKER_TAG=18.10
+  - BUILD_FLAVOR=ubuntu DOCKER_TAG=19.10
   - BUILD_FLAVOR=debian DOCKER_TAG=10
 
 before_install:

--- a/Makefile.am
+++ b/Makefile.am
@@ -30,7 +30,8 @@ UBUNTU_FLAVOURS =	\
     xUbuntu_17.10	\
     xUbuntu_18.04	\
     xUbuntu_18.10	\
-    xUbuntu_19.04
+    xUbuntu_19.04	\
+    xUbuntu_19.10
 
 show-debian:
 	@echo "Debian flavors: $(DEBIAN_FLAVOURS)"

--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Apr 06 16:22:29 CEST 2020 - aschnell@suse.com
+
+- updated translations (bsc#1149754)
+
+-------------------------------------------------------------------
 Thu Jan 16 13:01:15 UTC 2020 - Martin Vidner <mvidner@suse.com>
 
 - Fix "Snapper is not creating the post snapshot" (bsc#1160938)

--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -2,6 +2,7 @@
 Mon Apr 06 16:22:29 CEST 2020 - aschnell@suse.com
 
 - updated translations (bsc#1149754)
+- generate dsc file for Ubuntu 19.10
 
 -------------------------------------------------------------------
 Thu Jan 16 13:01:15 UTC 2020 - Martin Vidner <mvidner@suse.com>


### PR DESCRIPTION
This PR merely adds a changelog entry to satisfy tools used by CI so that we get the latest translations from the git repository to openSUSE Factory and SLE15 SP2.

For https://trello.com/c/TZKOPN8W/1089-1-check-status-of-snapper-translations-for-sle-12-sp5-and-sle-15-sp2.