### PR TITLE
Workaround for a Travis Tumbleweed build error

### DIFF
--- a/Dockerfile.tumbleweed
+++ b/Dockerfile.tumbleweed
@@ -14,7 +14,7 @@ RUN zypper mr -d repo-non-oss
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
 # https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
 # why we need "zypper clean -a" at the end
-RUN zypper --non-interactive in --no-recommends --force-resolution ruby && zypper clean -a
+RUN zypper --non-interactive in --no-recommends --force-resolution util-linux ruby && zypper clean -a
 
 # add the YaST repository - we need rubygem-coveralls-lcov
 RUN zypper ar -f http://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast_tw


### PR DESCRIPTION
- Related to https://travis-ci.org/github/openSUSE/snapper/jobs/687217532
- Explicitly install "util-linux", the automatically selected  "busybox-util-linux" creates conflicts later
- It looks like "ruby" has some weaker dependency and installing "busybox-util-linux" is enough, later some other tool needs full "util-linux" and it conflicts with the already installed "busybox-util-linux"