### PR TITLE
Improve openSUSE Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ services:
 
 # define the build matrix
 env:
-  - BUILD_FLAVOR=tumbleweed
-  - BUILD_FLAVOR=leap
-  - BUILD_FLAVOR=fedora DOCKER_TAG=31
-  - BUILD_FLAVOR=ubuntu DOCKER_TAG=19.10
-  - BUILD_FLAVOR=debian DOCKER_TAG=10
+  - BUILD_FLAVOR=tumbleweed DOCKER_TAG=latest YAST_REPO=openSUSE_Tumbleweed
+  - BUILD_FLAVOR=leap       DOCKER_TAG=15.1   YAST_REPO=openSUSE_Leap_15.1_Update
+  - BUILD_FLAVOR=fedora     DOCKER_TAG=31
+  - BUILD_FLAVOR=ubuntu     DOCKER_TAG=19.10
+  - BUILD_FLAVOR=debian     DOCKER_TAG=10
 
 before_install:
   # use the Dockerfile.<distro> file for building the image
-  - docker build -f Dockerfile.$BUILD_FLAVOR -t snapper-devel --build-arg BUILD_FLAVOR=$BUILD_FLAVOR --build-arg DOCKER_TAG=$DOCKER_TAG .
+  - docker build -f Dockerfile.$BUILD_FLAVOR -t snapper-devel --build-arg BUILD_FLAVOR=$BUILD_FLAVOR --build-arg DOCKER_TAG=$DOCKER_TAG --build-arg YAST_REPO=$YAST_REPO .
 
 script:
   # run the respective .travis.<distro>.sh script

--- a/Dockerfile.tumbleweed
+++ b/Dockerfile.tumbleweed
@@ -2,9 +2,13 @@
 # so use a parametrized Dockerfile. See
 # https://docs.docker.com/engine/reference/builder/#from
 ARG BUILD_FLAVOR
+ARG DOCKER_TAG
 
 # Build the latest openSUSE Tumbleweed or Leap image
-FROM opensuse/${BUILD_FLAVOR}
+FROM opensuse/${BUILD_FLAVOR}:${DOCKER_TAG}
+
+# this one needs to be defined after "FROM" so the value is available in "RUN" later
+ARG YAST_REPO
 
 # the NON-OSS repo is not needed, save the network bandwidth and some time (~5 seconds) for each refresh
 RUN zypper mr -d repo-non-oss
@@ -16,8 +20,7 @@ RUN zypper mr -d repo-non-oss
 RUN zypper --non-interactive in --no-recommends --force-resolution util-linux ruby && zypper clean -a
 
 # add the YaST repository - we need rubygem-coveralls-lcov
-RUN zypper ar -f http://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast_tw
-RUN zypper ar -f http://download.opensuse.org/repositories/YaST:/Head/openSUSE_Leap_15.1_Update/ yast_lp
+RUN zypper ar -f http://download.opensuse.org/repositories/YaST:/Head/${YAST_REPO}/ yast
 RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   zypper --non-interactive --gpg-auto-import-keys \
   in --no-recommends \


### PR DESCRIPTION
- Do not mix the Leap and Tumbleweed YaST repositories
- Pin the openSUSE version to 15.1 (the "latest" might be switched to 15.2 anytime in the future causing inconsistenty with the used 15.1 YaST repository)
- Later we can run 15.1 and 15.2 in parallel if needed or just switch from 15.1 to 15.2