### PR TITLE
- updated debian changelog

### DIFF
--- a/dists/debian/changelog
+++ b/dists/debian/changelog
@@ -1,3 +1,11 @@
+snapper (0.8.13) stable; urgency=low
+
+  * Updated to version 0.8.13
+
+  * call fsync after writing snapshot info file (bsc#1078336)
+
+ -- Arvin Schnell <aschnell@suse.com>  Thu, 27 Aug 27 2020 12:35:09 +0000
+
 snapper (0.8.12) stable; urgency=low
 
   * Updated to version 0.8.12


### PR DESCRIPTION
Still for https://github.com/openSUSE/snapper/pull/548.