### PR TITLE
Improve snapperd dbus activation

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -5,7 +5,7 @@
 EXTRA_DIST = sysconfig.snapper base.txt lvm.txt x11.txt snapper.logrotate	\
 	default-config org.opensuse.Snapper.conf org.opensuse.Snapper.service	\
 	zypp-plugin.conf timeline.service timeline.timer cleanup.service	\
-	cleanup.timer boot.service boot.timer
+	cleanup.timer boot.service boot.timer snapperd.service
 
 install-data-local:
 	install -D -m 644 snapper.logrotate $(DESTDIR)/etc/logrotate.d/snapper
@@ -27,6 +27,7 @@ install-data-local:
 	install -D -m 644 cleanup.timer $(DESTDIR)/usr/lib/systemd/system/snapper-cleanup.timer
 	install -D -m 644 boot.service $(DESTDIR)/usr/lib/systemd/system/snapper-boot.service
 	install -D -m 644 boot.timer $(DESTDIR)/usr/lib/systemd/system/snapper-boot.timer
+	install -D -m 644 snapperd.service $(DESTDIR)/usr/lib/systemd/system/snapperd.service
 
 if HAVE_ZYPP
 	install -D -m 644 zypp-plugin.conf $(DESTDIR)/etc/snapper/zypp-plugin.conf

--- a/data/org.opensuse.Snapper.service
+++ b/data/org.opensuse.Snapper.service
@@ -3,3 +3,4 @@
 Name=org.opensuse.Snapper
 Exec=/usr/sbin/snapperd
 User=root
+SystemdService=snapperd.service

--- a/data/snapperd.service
+++ b/data/snapperd.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=DBus interface for snapper
+Documentation=man:snapperd(8)
+
+[Service]
+Type=dbus
+BusName=org.opensuse.Snapper
+ExecStart=/usr/sbin/snapperd

--- a/snapper.spec.in
+++ b/snapper.spec.in
@@ -145,7 +145,7 @@ make %{?_smp_mflags} check VERBOSE=1
 
 %pre
 %if 0%{?suse_version}
-%service_add_pre snapper-boot.service snapper-boot.timer snapper-cleanup.service snapper-cleanup.timer snapper-timeline.service snapper-timeline.timer
+%service_add_pre snapper-boot.service snapper-boot.timer snapper-cleanup.service snapper-cleanup.timer snapper-timeline.service snapper-timeline.timer snapperd.service
 %endif
 
 %post
@@ -160,17 +160,17 @@ if [ -f /etc/cron.daily/suse.de-snapper ]; then
  systemctl preset snapper-cleanup.timer || :
  systemctl is-enabled -q snapper-cleanup.timer && systemctl start snapper-cleanup.timer || :
 fi
-%service_add_post snapper-boot.service snapper-boot.timer snapper-cleanup.service snapper-cleanup.timer snapper-timeline.service snapper-timeline.timer
+%service_add_post snapper-boot.service snapper-boot.timer snapper-cleanup.service snapper-cleanup.timer snapper-timeline.service snapper-timeline.timer snapperd.service
 %endif
 
 %preun
 %if 0%{?suse_version}
-%service_del_preun snapper-boot.service snapper-boot.timer snapper-cleanup.service snapper-cleanup.timer snapper-timeline.service snapper-timeline.timer
+%service_del_preun snapper-boot.service snapper-boot.timer snapper-cleanup.service snapper-cleanup.timer snapper-timeline.service snapper-timeline.timer snapperd.service
 %endif
 
 %postun
 %if 0%{?suse_version}
-%service_del_postun snapper-boot.service snapper-boot.timer snapper-cleanup.service snapper-cleanup.timer snapper-timeline.service snapper-timeline.timer
+%service_del_postun snapper-boot.service snapper-boot.timer snapper-cleanup.service snapper-cleanup.timer snapper-timeline.service snapper-timeline.timer snapperd.service
 %endif
 
 %files -f snapper.lang
@@ -189,7 +189,7 @@ fi
 %doc %{_mandir}/*/mksubvolume.8*
 %endif
 %config(noreplace) %{_sysconfdir}/logrotate.d/snapper
-%{_unitdir}/snapper-*.*
+%{_unitdir}/snapper*.*
 %config /etc/dbus-1/system.d/org.opensuse.Snapper.conf
 %{_datadir}/dbus-1/system-services/org.opensuse.Snapper.service
 


### PR DESCRIPTION
Dbus needs to know the systemd unit to activate in order to avoid using
a setuid launch helper. Ie this makes snapperd work in paranoid
permissions mode.