### PR TITLE
fix LVM setup for LVM with one character long names

### DIFF
--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 31 17:18:14 CEST 2020 - aschnell@suse.com
+
+- fix LVM setup for volume groups and logical volumes with one
+  character long names (gh#openSUSE/snapper#465)
+
+-------------------------------------------------------------------
 Fri Aug 28 11:06:23 CEST 2020 - aschnell@suse.com
 
 - improved error messages for wrong command line options and

--- a/snapper/LvmUtils.cc
+++ b/snapper/LvmUtils.cc
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) [2011-2014] Novell, Inc.
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact Novell, Inc.
+ *
+ * To contact Novell about this file by physical or electronic mail, you may
+ * find current contact information at www.novell.com.
+ */
+
+
+#include <boost/algorithm/string.hpp>
+
+#include "snapper/LvmUtils.h"
+#include "snapper/Regex.h"
+#include "snapper/AppUtil.h"
+
+
+namespace snapper
+{
+
+    namespace LvmUtils
+    {
+
+	pair<string, string>
+	split_device_name(const string& name)
+	{
+	    Regex rx("^/dev/mapper/(.*[^-])-([^-].*)$");
+	    if (!rx.match(name))
+		throw std::runtime_error("faild to split device name into volume group and "
+					 "logical volume name");
+
+	    string vg_name = boost::replace_all_copy(rx.cap(1), "--", "-");
+	    string lv_name = boost::replace_all_copy(rx.cap(2), "--", "-");
+
+	    return make_pair(vg_name, lv_name);
+	}
+
+    }
+}

--- a/snapper/LvmUtils.h
+++ b/snapper/LvmUtils.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) [2011-2014] Novell, Inc.
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact Novell, Inc.
+ *
+ * To contact Novell about this file by physical or electronic mail, you may
+ * find current contact information at www.novell.com.
+ */
+
+
+#ifndef SNAPPER_LVM_UTILS_H
+#define SNAPPER_LVM_UTILS_H
+
+
+#include <utility>
+#include <string>
+
+
+namespace snapper
+{
+    using std::string;
+    using std::pair;
+
+
+    namespace LvmUtils
+    {
+
+	std::pair<string, string> split_device_name(const string& name);
+
+    }
+
+}
+
+
+#endif

--- a/snapper/Makefile.am
+++ b/snapper/Makefile.am
@@ -48,7 +48,8 @@ endif
 if ENABLE_LVM
 libsnapper_la_SOURCES +=				\
 	Lvm.cc			Lvm.h			\
-	LvmCache.cc		LvmCache.h
+	LvmCache.cc		LvmCache.h		\
+	LvmUtils.cc		LvmUtils.h
 endif
 
 if ENABLE_ROLLBACK

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -8,7 +8,7 @@ LDADD = ../snapper/libsnapper.la ../dbus/libdbus.la -lboost_unit_test_framework
 
 check_PROGRAMS = sysconfig-get1.test dirname1.test basename1.test		    \
 	equal-date.test dbus-escape.test cmp-lt.test humanstring.test table.test    \
-	csv-formatter.test json-formatter.test getopts.test
+	csv-formatter.test json-formatter.test getopts.test lvm-utils.test
 
 if ENABLE_BTRFS_QUOTA
 check_PROGRAMS += qgroup1.test
@@ -31,3 +31,5 @@ csv_formatter_test_LDADD = -lboost_unit_test_framework ../client/utils/libutils.
 json_formatter_test_LDADD = -lboost_unit_test_framework ../client/utils/libutils.la
 
 getopts_test_LDADD = -lboost_unit_test_framework ../client/utils/libutils.la
+
+lvm_utils_test_LDADD = -lboost_unit_test_framework ../snapper/libsnapper.la

--- a/testsuite/lvm-utils.cc
+++ b/testsuite/lvm-utils.cc
@@ -1,0 +1,25 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE basename1
+
+#include <boost/test/unit_test.hpp>
+
+#include <snapper/LvmUtils.h>
+
+using namespace snapper;
+
+
+BOOST_AUTO_TEST_CASE(split_device_name)
+{
+    std::pair<string, string> n1 = LvmUtils::split_device_name("/dev/mapper/system-root");
+    BOOST_CHECK_EQUAL(n1.first, "system");
+    BOOST_CHECK_EQUAL(n1.second, "root");
+
+    std::pair<string, string> n2 = LvmUtils::split_device_name("/dev/mapper/vg--system-lv--root");
+    BOOST_CHECK_EQUAL(n2.first, "vg-system");
+    BOOST_CHECK_EQUAL(n2.second, "lv-root");
+
+    std::pair<string, string> n3 = LvmUtils::split_device_name("/dev/mapper/s-r");
+    BOOST_CHECK_EQUAL(n3.first, "s");
+    BOOST_CHECK_EQUAL(n3.second, "r");
+}


### PR DESCRIPTION
Improved fix for https://github.com/openSUSE/snapper/pull/465.