### PR TITLE
- fixed BuildRequires for ScientificLinux

### DIFF
--- a/snapper.spec.in
+++ b/snapper.spec.in
@@ -76,7 +76,7 @@ BuildRequires:  xsltproc
 BuildRequires:  libzypp(plugin:commit)
 %endif
 BuildRequires:  pam-devel
-%if 0%{?fedora_version} || 0%{?centos_version} || 0%{?rhel_version}
+%if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version} || 0%{?scientificlinux_version}
 BuildRequires:  json-c-devel
 %else
 BuildRequires:  libjson-c-devel


### PR DESCRIPTION
Fixed BuildRequires for ScientificLinux. Unfortunately in ScientificLinux 7 libxml seems to old and ScientificLinux 8 is missing in the build service.
