### PR TITLE
- package new snapperd.service file on Debian

### DIFF
--- a/client/utils/CsvFormatter.cc
+++ b/client/utils/CsvFormatter.cc
@@ -35,7 +35,7 @@ namespace snapper
     namespace cli
     {
 
-	const std::string CsvFormatter::default_separator = ",";
+	const string CsvFormatter::default_separator = ",";
 
 
 	string
@@ -92,14 +92,14 @@ namespace snapper
 
 
 	string
-	CsvFormatter::double_quotes(const string& value)
+	CsvFormatter::double_quotes(const string& value) const
 	{
 	    return boost::algorithm::replace_all_copy(value, "\"", "\"\"" );
 	}
 
 
 	string
-	CsvFormatter::enclose_with_quotes(const string& value)
+	CsvFormatter::enclose_with_quotes(const string& value) const
 	{
 	    return "\"" + value + "\"";
 	}

--- a/client/utils/CsvFormatter.h
+++ b/client/utils/CsvFormatter.h
@@ -58,9 +58,9 @@ namespace snapper
 
 	    bool has_special_chars(const string& value) const;
 
-	    static string double_quotes(const string& value);
+	    string double_quotes(const string& value) const;
 
-	    static string enclose_with_quotes(const string& value);
+	    string enclose_with_quotes(const string& value) const;
 
 	    const vector<string> header;
 	    const vector<vector<string>> rows;

--- a/dists/debian/snapper.install
+++ b/dists/debian/snapper.install
@@ -6,3 +6,4 @@ usr/bin/snapper
 usr/sbin/snapperd
 usr/share/dbus-1/system-services/org.opensuse.Snapper.service
 usr/share/locale/*/LC_MESSAGES/snapper.mo
+usr/lib/systemd/system/snapperd.service

--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep 04 19:10:26 CEST 2020 - aschnell@suse.com
+
+- package new snapperd.service file on Debian based distributions
+  (gh#openSUSE/snapper#557)
+
+-------------------------------------------------------------------
 Tue Sep 01 09:50:00 CEST 2020 - lnussel@suse.com
 
 - activate snapperd using systemd service


### PR DESCRIPTION
The new file snapperd.service was missing in the Debian file list.

Fixes https://github.com/openSUSE/snapper/issues/557.
