### PR TITLE
Undefine stdout and stderr in SystemCmd.h.

### DIFF
--- a/snapper/SystemCmd.h
+++ b/snapper/SystemCmd.h
@@ -32,6 +32,9 @@
 #include <list>
 #include <boost/noncopyable.hpp>
 
+// These macro definitions collide with SystemCmd::(stdin|stderr)(...)
+#undef stderr
+#undef stdout
 
 namespace snapper
 {


### PR DESCRIPTION
musl's stdio.h provides the stdout and stderr macros, which conflict
with the method definitions in SystemCmd and cause compilation errors.

Taken from #220 