### PR TITLE
Avoid glibc-specific time extensions.

### DIFF
--- a/client/utils/equal-date.cc
+++ b/client/utils/equal-date.cc
@@ -24,6 +24,8 @@
 
 #include "equal-date.h"
 
+#define isleapyear(year) \
+    ((year) % 4 == 0 && ((year) % 100 != 0 || (year) % 400 == 0))
 
 int
 yday_of_weeks_monday(const struct tm& tmp)
@@ -35,7 +37,7 @@ yday_of_weeks_monday(const struct tm& tmp)
 int
 days_in_year(const struct tm& tmp)
 {
-    return __isleap(tmp.tm_year) ? 366 : 365;
+    return isleapyear(tmp.tm_year) ? 366 : 365;
 }
 
 

--- a/snapper/AppUtil.cc
+++ b/snapper/AppUtil.cc
@@ -285,10 +285,10 @@ namespace snapper
     {
 	struct tm s;
 	memset(&s, 0, sizeof(s));
-	const char* p = strptime(str.c_str(), "%F %T", &s);
+	const char* p = strptime(str.c_str(), "%Y-%m-%d %T", &s);
 	if (!p || *p != '\0')
 	    return (time_t)(-1);
-	return utc ? timegm(&s) : timelocal(&s);
+	return utc ? timegm(&s) : mktime(&s);
     }
 
 


### PR DESCRIPTION
* Use mktime instead of timelocal
* Replace glibc specific time format string
* Inline private __isleap() macro from glibc

Taken from #220 