### PR TITLE
Search for GNU compatible gettext implementation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,6 +183,9 @@ fi
 
 AC_CHECK_HEADER(acl/libacl.h,[],[AC_MSG_ERROR([Cannout find libacl headers. Please install libacl-devel])])
 
+AM_GNU_GETTEXT_VERSION([0.18.1])
+AM_GNU_GETTEXT([external])
+
 AC_SUBST(VERSION)
 AC_SUBST(LIBVERSION_MAJOR)
 AC_SUBST(LIBVERSION_MINOR)

--- a/snapper/Makefile.am
+++ b/snapper/Makefile.am
@@ -63,7 +63,7 @@ libsnapper_la_SOURCES +=				\
 endif
 
 libsnapper_la_LDFLAGS = -version-info @LIBVERSION_INFO@
-libsnapper_la_LIBADD = -lboost_thread -lboost_system $(XML2_LIBS) -lacl -lz -lm
+libsnapper_la_LIBADD = -lboost_thread -lboost_system @LTLIBINTL@ $(XML2_LIBS) -lacl -lz -lm
 if ENABLE_ROLLBACK
 libsnapper_la_LIBADD += -lmount
 endif


### PR DESCRIPTION
snapper uses a GNU specific symbol in gettext (_nl_msg_cat_cntr), which
is not provided by musl's gettext implementation.

Based on #220