### PR TITLE
- state in man-pages that ext4 support is discontinued

### DIFF
--- a/doc/snapper.xml.in
+++ b/doc/snapper.xml.in
@@ -39,7 +39,7 @@
 
     <para>Snapper never modifies the content of snapshots. Thus snapper creates
     read-only snapshots if supported by the kernel. Supported filesystems are
-    btrfs and ext4 as well as snapshots of LVM logical volumes with
+    btrfs and ext4 (discontinued) as well as snapshots of LVM logical volumes with
     thin-provisioning. Some filesystems might not be supported depending on your
     installation.</para>
   </refsect1>
@@ -336,9 +336,10 @@
 	    <varlistentry>
 	      <term><option>-f, --fstype</option> <replaceable>fstype</replaceable></term>
 	      <listitem>
-		<para>Manually set filesystem type. Supported values are btrfs, ext4 and lvm. For
-		lvm, snapper uses LVM thin-provisioned snapshots. The filesystem type on top of
-		LVM must be provided in parentheses, e.g. lvm(xfs).</para>
+		<para>Manually set filesystem type. Supported values are btrfs, ext4
+		(discontinued) and lvm. For lvm, snapper uses LVM thin-provisioned snapshots.
+		The filesystem type on top of LVM must be provided in parentheses,
+		e.g. lvm(xfs).</para>
 		<para>Without this option snapper tries to detect the filesystem.</para>
 	      </listitem>
 	    </varlistentry>

--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 19 11:49:29 CET 2020 - aschnell@suse.com
+
+- state in man-pages that ext4 support is discontinued
+  (gh#openSUSE/snapper#331)
+
+-------------------------------------------------------------------
 Wed Nov 18 12:13:56 CET 2020 - aschnell@suse.com
 
 - use C++11 regexes instead of own regcomp/regexec wrapper class


### PR DESCRIPTION
State in man-pages that ext4 support is discontinued.

See https://github.com/openSUSE/snapper/issues/331.