### PR TITLE
- do not override passwd after getpwuid_r et.al. calls

### DIFF
--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov 24 11:58:44 CET 2020 - aschnell@suse.com
+
+- do not override passwd after getpwuid_r et.al. calls
+  (gh#openSUSE/snapper#589)
+
+-------------------------------------------------------------------
 Thu Nov 19 11:49:29 CET 2020 - aschnell@suse.com
 
 - state in man-pages that ext4 support is discontinued

--- a/pam/pam_snapper.c
+++ b/pam/pam_snapper.c
@@ -528,8 +528,6 @@ static int get_ugid( pam_handle_t * pamh, const char *pam_user, uid_t * uid, gid
 		return -1;
 	}
 
-	memset( pwd.pw_passwd, 0, strlen( pwd.pw_passwd ) );
-
 	*uid = pwd.pw_uid;
 	*gid = pwd.pw_gid;
 

--- a/snapper/AppUtil.cc
+++ b/snapper/AppUtil.cc
@@ -315,8 +315,6 @@ namespace snapper
 	if (e != 0 || result == NULL)
 	    return false;
 
-	memset(pwd.pw_passwd, 0, strlen(pwd.pw_passwd));
-
 	username = pwd.pw_name;
 	gid = pwd.pw_gid;
 
@@ -338,8 +336,6 @@ namespace snapper
 
 	if (e != 0 || result == NULL)
 	    return false;
-
-	memset(pwd.pw_passwd, 0, strlen(pwd.pw_passwd));
 
 	dir = pwd.pw_dir;
 
@@ -365,8 +361,6 @@ namespace snapper
 	    return false;
 	}
 
-	memset(pwd.pw_passwd, 0, strlen(pwd.pw_passwd));
-
 	uid = pwd.pw_uid;
 
 	return true;
@@ -390,8 +384,6 @@ namespace snapper
 	    y2war("couldn't find groupname '" << groupname << "'");
 	    return false;
 	}
-
-	memset(grp.gr_passwd, 0, strlen(grp.gr_passwd));
 
 	gid = grp.gr_gid;
 


### PR DESCRIPTION
Do not override passwd after getpwuid_r et.al. calls. See https://github.com/openSUSE/snapper/issues/589.