### PR TITLE
- continue with other configs if one config is broken

### DIFF
--- a/client/proxy.cc
+++ b/client/proxy.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2016-2017] SUSE LLC
+ * Copyright (c) [2016-2020] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -52,6 +52,14 @@ ProxyConfig::getValue(const string& key, string& value) const
 
     value = it->second;
     return true;
+}
+
+
+bool
+ProxyConfig::is_yes(const char* key) const
+{
+    map<string, string>::const_iterator pos = values.find(key);
+    return pos != values.end() && pos->second == "yes";
 }
 
 

--- a/client/proxy.h
+++ b/client/proxy.h
@@ -82,6 +82,8 @@ public:
 
     bool getValue(const string& key, string& value) const;
 
+    bool is_yes(const char* key) const;
+
 private:
 
     map<string, string> values;

--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 04 10:05:05 CET 2020 - aschnell@suse.com
+
+- in systemd-helper continue with other configs if one config is
+  broken (gh#openSUSE/snapper#495)
+
+-------------------------------------------------------------------
 Thu Dec 03 10:12:04 CET 2020 - aschnell@suse.com
 
 - fixed compilation with --disable-btrfs (gh#openSUSE/snapper#505)


### PR DESCRIPTION
More fine tuned error handling to continue with other configs if one config is broken. See https://github.com/openSUSE/snapper/issues/495.