### PR TITLE
- fixed compilation in latest openSUSE:Factory

### DIFF
--- a/snapper/Makefile.am
+++ b/snapper/Makefile.am
@@ -64,7 +64,7 @@ libsnapper_la_SOURCES +=				\
 endif
 
 libsnapper_la_LDFLAGS = -version-info @LIBVERSION_INFO@
-libsnapper_la_LIBADD = -lboost_thread -lboost_system $(XML2_LIBS) -lacl -lz -lm
+libsnapper_la_LIBADD = -lboost_thread -lboost_system $(XML2_LIBS) -lacl
 if ENABLE_ROLLBACK
 libsnapper_la_LIBADD += -lmount
 endif


### PR DESCRIPTION
For unclear reasons linking suddenly fails with 'cannot find -lz'. It works without explicit linking libz (libz seems to be dragged in by libxml2).
