### PR TITLE
- fixed testsuite for equal-date

### DIFF
--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Jan 25 11:29:45 CET 2021 - aschnell@suse.com
+
+- fixed testsuite for equal-date (gh#openSUSE/snapper#526)
+
+-------------------------------------------------------------------
 Thu Dec 17 12:20:59 CET 2020 - aschnell@suse.com
 
 - added option to abbreviate columns in table (see

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -9,7 +9,7 @@ LDADD = ../snapper/libsnapper.la ../dbus/libdbus.la -lboost_unit_test_framework
 check_PROGRAMS = sysconfig-get1.test dirname1.test basename1.test 		\
 	equal-date.test dbus-escape.test cmp-lt.test humanstring.test 		\
 	table.test table-formatter.test csv-formatter.test json-formatter.test	\
-	getopts.test
+	getopts.test scan-datetime.test
 
 if ENABLE_BTRFS_QUOTA
 check_PROGRAMS += qgroup1.test
@@ -26,6 +26,8 @@ AM_DEFAULT_SOURCE_EXT = .cc
 EXTRA_DIST = $(noinst_SCRIPTS) sysconfig-get1.txt sysconfig-set1.txt
 
 equal_date_test_LDADD = -lboost_unit_test_framework ../client/utils/libutils.la
+
+scan_datetime_test_LDADD = -lboost_unit_test_framework ../client/utils/libutils.la
 
 humanstring_test_LDADD = -lboost_unit_test_framework ../client/utils/libutils.la
 

--- a/testsuite/equal-date.cc
+++ b/testsuite/equal-date.cc
@@ -5,18 +5,25 @@
 #include <boost/test/unit_test.hpp>
 
 #include "../client/utils/equal-date.h"
+#include "../snapper/AppUtil.h"
+
+using namespace snapper;
 
 
 bool
 equal_week(const char* s1, const char* s2)
 {
+    // use interim time_t since strptime on musl does not set tm_yday
+
+    time_t t1 = scan_datetime(s1, true);
     struct tm tmp1;
     memset(&tmp1, 0, sizeof(tmp1));
-    strptime(s1, "%Y-%m-%d", &tmp1);
+    gmtime_r(&t1, &tmp1);
 
+    time_t t2 = scan_datetime(s2, true);
     struct tm tmp2;
     memset(&tmp2, 0, sizeof(tmp2));
-    strptime(s2, "%Y-%m-%d", &tmp2);
+    gmtime_r(&t2, &tmp2);
 
     return equal_week(tmp1, tmp2);
 }
@@ -25,46 +32,46 @@ equal_week(const char* s1, const char* s2)
 BOOST_AUTO_TEST_CASE(test1)
 {
     // 2012 is a leap year
-    BOOST_CHECK(equal_week("2011-12-31", "2012-01-01"));
-    BOOST_CHECK(equal_week("2012-01-01", "2011-12-31"));
+    BOOST_CHECK(equal_week("2011-12-31 00:00:00", "2012-01-01 00:00:00"));
+    BOOST_CHECK(equal_week("2012-01-01 00:00:00", "2011-12-31 00:00:00"));
 }
 
 
 BOOST_AUTO_TEST_CASE(test2)
 {
     // 2012 is a leap year
-    BOOST_CHECK(equal_week("2012-12-31", "2013-01-01"));
-    BOOST_CHECK(equal_week("2013-01-01", "2012-12-31"));
+    BOOST_CHECK(equal_week("2012-12-31 00:00:00", "2013-01-01 00:00:00"));
+    BOOST_CHECK(equal_week("2013-01-01 00:00:00", "2012-12-31 00:00:00"));
 }
 
 
 BOOST_AUTO_TEST_CASE(test3)
 {
     // Saturday and Sunday
-    BOOST_CHECK(equal_week("2014-01-04", "2014-01-05"));
-    BOOST_CHECK(equal_week("2014-01-05", "2014-01-04"));
+    BOOST_CHECK(equal_week("2014-01-04 00:00:00", "2014-01-05 00:00:00"));
+    BOOST_CHECK(equal_week("2014-01-05 00:00:00", "2014-01-04 00:00:00"));
 
     // Sunday and Monday
-    BOOST_CHECK(!equal_week("2014-01-05", "2014-01-06"));
-    BOOST_CHECK(!equal_week("2014-01-06", "2014-01-05"));
+    BOOST_CHECK(!equal_week("2014-01-05 00:00:00", "2014-01-06 00:00:00"));
+    BOOST_CHECK(!equal_week("2014-01-06 00:00:00", "2014-01-05 00:00:00"));
 
     // Monday and Tuesday
-    BOOST_CHECK(equal_week("2014-01-06", "2014-01-07"));
-    BOOST_CHECK(equal_week("2014-01-07", "2014-01-06"));
+    BOOST_CHECK(equal_week("2014-01-06 00:00:00", "2014-01-07 00:00:00"));
+    BOOST_CHECK(equal_week("2014-01-07 00:00:00", "2014-01-06 00:00:00"));
 }
 
 
 BOOST_AUTO_TEST_CASE(test4)
 {
     // 2014-12-31 is a Wednesday, 2015-01-01 is a Thursday
-    BOOST_CHECK(equal_week("2014-12-31", "2015-01-01"));
-    BOOST_CHECK(equal_week("2015-01-01", "2014-12-31"));
+    BOOST_CHECK(equal_week("2014-12-31 00:00:00", "2015-01-01 00:00:00"));
+    BOOST_CHECK(equal_week("2015-01-01 00:00:00", "2014-12-31 00:00:00"));
 }
 
 
 BOOST_AUTO_TEST_CASE(test5)
 {
     // 2017-12-31 is a Sunday, 2018-01-01 is a Monday
-    BOOST_CHECK(!equal_week("2017-12-31", "2018-01-01"));
-    BOOST_CHECK(!equal_week("2018-01-01", "2017-12-31"));
+    BOOST_CHECK(!equal_week("2017-12-31 00:00:00", "2018-01-01 00:00:00"));
+    BOOST_CHECK(!equal_week("2018-01-01 00:00:00", "2017-12-31 00:00:00"));
 }

--- a/testsuite/scan-datetime.cc
+++ b/testsuite/scan-datetime.cc
@@ -1,0 +1,30 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE snapper
+
+#include <boost/test/unit_test.hpp>
+
+#include "../snapper/AppUtil.h"
+
+using namespace snapper;
+
+
+BOOST_AUTO_TEST_CASE(test1)
+{
+    time_t t1 = scan_datetime("2020-03-04 12:34:56", true);
+
+    struct tm tmp1;
+    memset(&tmp1, 0, sizeof(tmp1));
+    gmtime_r(&t1, &tmp1);
+
+    BOOST_CHECK_EQUAL(tmp1.tm_year, 2020 - 1900);
+    BOOST_CHECK_EQUAL(tmp1.tm_mon, 3 - 1);
+    BOOST_CHECK_EQUAL(tmp1.tm_mday, 4);
+
+    BOOST_CHECK_EQUAL(tmp1.tm_yday, 31 + 28 + 4);
+    BOOST_CHECK_EQUAL(tmp1.tm_wday, 3);
+
+    BOOST_CHECK_EQUAL(tmp1.tm_hour, 12);
+    BOOST_CHECK_EQUAL(tmp1.tm_min, 34);
+    BOOST_CHECK_EQUAL(tmp1.tm_sec, 56);
+}


### PR DESCRIPTION
Fixed testsuite for equal-date (https://github.com/openSUSE/snapper/issues/526).