### PR TITLE
- move org.opensuse.Snapper.conf from /etc to /usr

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -18,7 +18,7 @@ install-data-local:
 	install -D -m 644 lvm.txt $(DESTDIR)/etc/snapper/filters/lvm.txt
 	install -D -m 644 x11.txt $(DESTDIR)/etc/snapper/filters/x11.txt
 
-	install -D -m 644 org.opensuse.Snapper.conf $(DESTDIR)/etc/dbus-1/system.d/org.opensuse.Snapper.conf
+	install -D -m 644 org.opensuse.Snapper.conf $(DESTDIR)/usr/share/dbus-1/system.d/org.opensuse.Snapper.conf
 	install -D -m 644 org.opensuse.Snapper.service $(DESTDIR)/usr/share/dbus-1/system-services/org.opensuse.Snapper.service
 
 if ENABLE_SYSTEMD

--- a/dists/debian/snapper.install
+++ b/dists/debian/snapper.install
@@ -1,9 +1,9 @@
 etc/cron.daily/snapper
 etc/cron.hourly/snapper
-etc/dbus-1/system.d/org.opensuse.Snapper.conf
 etc/logrotate.d/snapper
 usr/bin/snapper
 usr/sbin/snapperd
+usr/share/dbus-1/system.d/org.opensuse.Snapper.conf
 usr/share/dbus-1/system-services/org.opensuse.Snapper.service
 usr/share/locale/*/LC_MESSAGES/snapper.mo
 usr/lib/systemd/system/snapperd.service

--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr 08 14:05:19 CEST 2021 - aschnell@suse.com
+
+- move org.opensuse.Snapper.conf from /etc to /usr (bsc#1183398 and
+  gh#openSUSE/snapper#492)
+
+-------------------------------------------------------------------
 Wed Apr 07 10:24:33 CEST 2021 - aschnell@suse.com
 
 - avoid redundant quota rescans for same btrfs (see

--- a/snapper.spec.in
+++ b/snapper.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package snapper
 #
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2021 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -88,6 +88,7 @@ BuildRequires:  lcov
 %endif
 Requires:       diffutils
 Requires:       libsnapper@LIBVERSION_MAJOR@ = %version
+Requires:       systemd
 %if 0%{?suse_version}
 Recommends:     logrotate snapper-zypp-plugin
 Supplements:    btrfsprogs
@@ -193,7 +194,10 @@ fi
 %endif
 %config(noreplace) %{_sysconfdir}/logrotate.d/snapper
 %{_unitdir}/snapper*.*
-%config /etc/dbus-1/system.d/org.opensuse.Snapper.conf
+%if 0%{?suse_version} <= 1500
+%dir %{_datadir}/dbus-1/system.d
+%endif
+%{_datadir}/dbus-1/system.d/org.opensuse.Snapper.conf
 %{_datadir}/dbus-1/system-services/org.opensuse.Snapper.service
 
 %package -n libsnapper@LIBVERSION_MAJOR@


### PR DESCRIPTION
For https://bugzilla.suse.com/show_bug.cgi?id=1183398 and https://github.com/openSUSE/snapper/pull/492.