### PR TITLE
WIP. Help Wanted. Create a "latest" symlink along with BTRFS snapshot.

### DIFF
--- a/snapper/BtrfsUtils.cc
+++ b/snapper/BtrfsUtils.cc
@@ -119,8 +119,10 @@ namespace snapper
 
 #endif
 
-	    if (ioctl(fddst, BTRFS_IOC_SNAP_CREATE_V2, &args_v2) == 0)
+	    if (ioctl(fddst, BTRFS_IOC_SNAP_CREATE_V2, &args_v2) == 0) {
+		symlink(std::to_string(fd), "latest");
 		return;
+	    }
 	    else if (errno != ENOTTY && errno != EINVAL)
 		throw runtime_error_with_errno("ioctl(BTRFS_IOC_SNAP_CREATE_V2) failed", errno);
 


### PR DESCRIPTION
My attempt for adding a symlink to the latest snapshot. Partial fix for #436. Thus far only for BTRFS. 

I've only attempted this code with `symlink("bar", "foo");` which created the symlink "/foo" to "bar". As I understand the code, the integers `fd` and `fddst` are identifiers for the subvolume that need to be snapshotted and the target.

What still needs to be done is:

- [ ] Identify where the '.snapshots' directory is and create the symlink in there
- [ ] Use fd(dst) to determine the snapshot target name and thus the symlink target name
- [ ] Apply the same logic for ext4/lvm

Would love any assistance to get going!