### PR TITLE
- cache uid for each client

### DIFF
--- a/server/Client.h
+++ b/server/Client.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2012-2015] Novell, Inc.
- * Copyright (c) [2016,2018] SUSE LLC
+ * Copyright (c) [2016-2022] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -120,7 +120,7 @@ public:
 
     void dispatch(DBus::Connection& conn, DBus::Message& msg);
 
-    Client(const string& name, const Clients& clients);
+    Client(const string& name, uid_t uid, const Clients& clients);
     ~Client();
 
     list<Comparison*>::iterator find_comparison(Snapper* snapper, unsigned int number1,
@@ -140,6 +140,7 @@ public:
     void remove_mount(const string& config_name, unsigned int number);
 
     const string name;
+    const uid_t uid;
 
     list<Comparison*> comparisons;
 
@@ -192,7 +193,8 @@ public:
 
     iterator find(const string& name);
 
-    iterator add(const string& name);
+    iterator add(const string& name, uid_t uid);
+
     void remove_zombies();
 
     bool has_zombies() const;

--- a/server/MetaSnapper.cc
+++ b/server/MetaSnapper.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2012-2015] Novell, Inc.
- * Copyright (c) 2018 SUSE LLC
+ * Copyright (c) [2018-2022] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -124,37 +124,37 @@ MetaSnapper::setConfigInfo(const map<string, string>& raw)
 void
 MetaSnapper::set_permissions()
 {
-    uids.clear();
+    allowed_uids.clear();
 
     vector<string> users;
     if (config_info.getValue(KEY_ALLOW_USERS, users))
     {
-	for (vector<string>::const_iterator it = users.begin(); it != users.end(); ++it)
+	for (const string& user : users)
 	{
 	    uid_t tmp;
-	    if (get_user_uid(it->c_str(), tmp))
-		uids.push_back(tmp);
+	    if (get_user_uid(user.c_str(), tmp))
+		allowed_uids.push_back(tmp);
 	}
     }
 
-    sort(uids.begin(), uids.end());
-    uids.erase(unique(uids.begin(), uids.end()), uids.end());
+    sort(allowed_uids.begin(), allowed_uids.end());
+    allowed_uids.erase(unique(allowed_uids.begin(), allowed_uids.end()), allowed_uids.end());
 
-    gids.clear();
+    allowed_gids.clear();
 
     vector<string> groups;
     if (config_info.getValue(KEY_ALLOW_GROUPS, groups))
     {
-	for (vector<string>::const_iterator it = groups.begin(); it != groups.end(); ++it)
+	for (const string& group : groups)
 	{
 	    gid_t tmp;
-	    if (get_group_gid(it->c_str(), tmp))
-		gids.push_back(tmp);
+	    if (get_group_gid(group.c_str(), tmp))
+		allowed_gids.push_back(tmp);
 	}
     }
 
-    sort(gids.begin(), gids.end());
-    gids.erase(unique(gids.begin(), gids.end()), gids.end());
+    sort(allowed_gids.begin(), allowed_gids.end());
+    allowed_gids.erase(unique(allowed_gids.begin(), allowed_gids.end()), allowed_gids.end());
 }
 
 

--- a/server/MetaSnapper.h
+++ b/server/MetaSnapper.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2012-2015] Novell, Inc.
- * Copyright (c) 2018 SUSE LLC
+ * Copyright (c) [2018-2022] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -94,8 +94,8 @@ public:
     const ConfigInfo& getConfigInfo() const { return config_info; }
     void setConfigInfo(const map<string, string>& raw);
 
-    vector<uid_t> uids;
-    vector<gid_t> gids;
+    const vector<uid_t>& get_allowed_uids() const { return allowed_uids; }
+    const vector<gid_t>& get_allowed_gids() const { return allowed_gids; }
 
     Snapper* getSnapper();
 
@@ -110,6 +110,9 @@ private:
     ConfigInfo config_info;
 
     Snapper* snapper = nullptr;
+
+    vector<uid_t> allowed_uids;
+    vector<gid_t> allowed_gids;
 
 };
 

--- a/server/snapperd.cc
+++ b/server/snapperd.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2012-2015] Novell, Inc.
- * Copyright (c) [2018-2021] SUSE LLC
+ * Copyright (c) [2018-2022] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -93,12 +93,14 @@ MyMainLoop::method_call(DBus::Message& msg)
     {
 	boost::unique_lock<boost::shared_mutex> lock(big_mutex);
 
-	Clients::iterator client = clients.find(msg.get_sender());
+	const string name = msg.get_sender();
+
+	Clients::iterator client = clients.find(name);
 	if (client == clients.end())
 	{
-	    y2deb("client connected invisible '" << msg.get_sender() << "'");
-	    add_client_match(msg.get_sender());
-	    client = clients.add(msg.get_sender());
+	    y2deb("client connected invisible '" << name << "'");
+	    add_client_match(name);
+	    client = clients.add(name, get_unix_userid(msg));
 	    set_idle_timeout(seconds(-1));
 	}
 


### PR DESCRIPTION
Caching the value is good since ```dbus_bus_get_unix_user()``` is not so fast (important for thousands of calls).