### PR TITLE
Manpage: cron -> systemd

### DIFF
--- a/doc/snapper.xml.in
+++ b/doc/snapper.xml.in
@@ -98,7 +98,7 @@
       <para>Next to manual snapshot creation, snapshots are also created automatically.</para>
       <itemizedlist>
 	<listitem>
-	  <para>A systemd timer creates hourly snapshots, if TIMELINE_CREATE is enabled for a config.</para>
+	  <para>A cronjob or systemd timer creates hourly snapshots, if TIMELINE_CREATE is enabled for a config.</para>
 	</listitem>
 	<listitem>
 	  <para>Certain programs like YaST and zypper create pre/post

--- a/doc/snapper.xml.in
+++ b/doc/snapper.xml.in
@@ -98,7 +98,7 @@
       <para>Next to manual snapshot creation, snapshots are also created automatically.</para>
       <itemizedlist>
 	<listitem>
-	  <para>A cron-job creates hourly snapshots.</para>
+	  <para>A systemd timer creates hourly snapshots, if TIMELINE_CREATE is enabled for a config.</para>
 	</listitem>
 	<listitem>
 	  <para>Certain programs like YaST and zypper create pre/post


### PR DESCRIPTION
Signed-off-by: Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>

Hi,

I think this line in the manpage could use an update, as I could not find cron-jobs for snapper on a new Tumbleweed install - only the systemd timers seem to exist.

Best,
Georg