### PR TITLE
Implement generic plugin script support

### DIFF
--- a/doc/snapper.xml.in
+++ b/doc/snapper.xml.in
@@ -839,6 +839,41 @@
     <citerefentry><refentrytitle>snapper-configs</refentrytitle><manvolnum>5</manvolnum></citerefentry>.</para>
   </refsect1>
 
+  <refsect1 id='plugins'>
+    <title>PLUGINS</title>
+    <para>snapper can execute external scripts after certain actions. Scripts
+    have to be placed in <filename>/usr/lib/snapper/plugins</filename>.
+    The name has to start with a digit, execution order is alphabetical.</para>
+    <para>The first argument of a script is the action snapper executed. The
+      following actions are defined:</para>
+    <variablelist>
+      <varlistentry>
+	<term><option>create-snapshot <replaceable>subvolume</replaceable> <replaceable>snapshot-number</replaceable></option></term>
+	<listitem>
+	  <para>Executed when a new snapshot gets created</para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term><option>delete-snapshot <replaceable>subvolume</replaceable> <replaceable>snapshot-number</replaceable></option></term>
+	<listitem>
+	  <para>Executed when a snapshot is removed</para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term><option>modify-snapshot <replaceable>subvolume</replaceable> <replaceable>snapshot-number</replaceable></option></term>
+	<listitem>
+	  <para>Executed when a snapshot gets modified</para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term><option>set-default-snapshot <replaceable>subvolume</replaceable> <replaceable>snapshot-number</replaceable></option></term>
+	<listitem>
+	  <para>Executed when the default snapshot gets changed</para>
+	</listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+
   <refsect1 id='files'>
     <title>FILES</title>
     <variablelist>

--- a/snapper/Btrfs.cc
+++ b/snapper/Btrfs.cc
@@ -51,6 +51,7 @@
 #include "snapper/Btrfs.h"
 #include "snapper/BtrfsUtils.h"
 #include "snapper/File.h"
+#include "snapper/Hooks.h"
 #include "snapper/Snapper.h"
 #include "snapper/SnapperTmpl.h"
 #include "snapper/SnapperDefines.h"
@@ -1530,6 +1531,8 @@ namespace snapper
 		SDir snapshot_dir = openSnapshotDir(num);
 		subvolid_t id = get_id(snapshot_dir.fd());
 		set_default_id(general_dir.fd(), id);
+
+		Hooks::set_default_snapshot(subvolume, this, num);
 	    }
 	}
 	catch (const runtime_error& e)

--- a/snapper/Hooks.h
+++ b/snapper/Hooks.h
@@ -37,12 +37,14 @@ namespace snapper
     {
     public:
 
+	static void run_scripts(const list<string>& args);
 	static void create_config(const string& subvolume, const Filesystem* filesystem);
 	static void delete_config(const string& subvolume, const Filesystem* filesystem);
 
-	static void create_snapshot(const string& subvolume, const Filesystem* filesystem);
-	static void modify_snapshot(const string& subvolume, const Filesystem* filesystem);
-	static void delete_snapshot(const string& subvolume, const Filesystem* filesystem);
+	static void create_snapshot(const string& subvolume, const Filesystem* filesystem, const Snapshot& snapshot);
+	static void modify_snapshot(const string& subvolume, const Filesystem* filesystem, const Snapshot& snapshot);
+	static void delete_snapshot(const string& subvolume, const Filesystem* filesystem, const Snapshot& snapshot);
+	static void set_default_snapshot(const string& subvolume, const Filesystem* filesystem, unsigned int num);
 
 	static void rollback(const string& old_root, const string& new_root);
 

--- a/snapper/Snapshot.cc
+++ b/snapper/Snapshot.cc
@@ -733,7 +733,7 @@ namespace snapper
 	    SN_RETHROW(e);
 	}
 
-	Hooks::create_snapshot(snapper->subvolumeDir(), snapper->getFilesystem());
+	Hooks::create_snapshot(snapper->subvolumeDir(), snapper->getFilesystem(), snapshot);
 
 	return entries.insert(entries.end(), snapshot);
     }
@@ -753,7 +753,7 @@ namespace snapper
 
 	snapshot->writeInfo();
 
-	Hooks::modify_snapshot(snapper->subvolumeDir(), snapper->getFilesystem());
+	Hooks::modify_snapshot(snapper->subvolumeDir(), snapper->getFilesystem(), *snapshot);
     }
 
 
@@ -794,7 +794,7 @@ namespace snapper
 
 	entries.erase(snapshot);
 
-	Hooks::delete_snapshot(snapper->subvolumeDir(), snapper->getFilesystem());
+	Hooks::delete_snapshot(snapper->subvolumeDir(), snapper->getFilesystem(), *snapshot);
     }
 
 


### PR DESCRIPTION
Instead of hardcoding calls to specific scripts, just read the
content of /usr/lib/snapper/plugins and execute all scripts that
start with a digit.
Implemented for create_snapshot, modify_snapshot, delete_snapshot,
and set_default_snapshot for a start.