### PR TITLE
Fix build with GCC 12 (and musl)

### DIFF
--- a/dbus/DBusMessage.h
+++ b/dbus/DBusMessage.h
@@ -27,6 +27,7 @@
 
 #include <dbus/dbus.h>
 
+#include <ctime>
 #include <string>
 #include <vector>
 #include <list>


### PR DESCRIPTION
```
DBusMessage.h:239:34: error: 'time_t' has not been declared
  239 |     Hihi& operator>>(Hihi& hihi, time_t& data);
```

Include <ctime> to grab time_t.

Bug: https://bugs.gentoo.org/862094
Signed-off-by: Sam James <sam@gentoo.org>