### PR TITLE
Add build detection of libbtrfsutil and use for 'set default subvolume'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -179,6 +179,14 @@ PKG_CHECK_MODULES(XML2, libxml-2.0)
 PKG_CHECK_MODULES(JSONC, json-c, [], [AC_MSG_WARN([Cannot find json-c. Please install libjson-c-devel])])
 PKG_CHECK_MODULES(ZLIB, zlib)
 
+AC_CHECK_LIB(btrfsutil, btrfs_util_strerror)
+AC_CHECK_HEADERS([btrfsutil.h])
+
+# Conditional support for libbtrfsutil
+if test "x$ac_cv_lib_btrfsutil_btrfs_util_strerror" = "xyes"; then
+	PKG_CHECK_MODULES(LIBBTRFSUTIL, libbtrfsutil)
+fi
+
 AC_CHECK_HEADER(acl/libacl.h,[],[AC_MSG_ERROR([Cannout find libacl headers. Please install libacl-devel])])
 
 AC_SUBST(VERSION)

--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Thu Jan 12 12:00:00 PM CET 2023 - David Sterba <dsterba@suse.cz>
+
+- Add build support for libbtrfsutil
+- Use libbtrfsutil implementation for the following methods:
+  - check if a subvolume exists
+  - create subvolume, snapshot
+  - subvolume read-only check
+  - delete subvolume
+  - set/get default subvolume
+  - filesystem sync
+
+-------------------------------------------------------------------
 Tue Dec 27 13:20:38 UTC 2022 - Ludwig Nussel <lnussel@suse.com>
 
 - Replace transitional %usrmerged macro with regular version check

--- a/snapper/Makefile.am
+++ b/snapper/Makefile.am
@@ -67,6 +67,10 @@ libsnapper_la_LIBADD = -lboost_thread -lboost_system $(XML2_LIBS) -lacl $(ZLIB_L
 if ENABLE_ROLLBACK
 libsnapper_la_LIBADD += -lmount
 endif
+if ENABLE_BTRFS
+libsnapper_la_CPPFLAGS += $(LIBBTRFSUTIL_CFLAGS)
+libsnapper_la_LIBADD += $(LIBBTRFSUTIL_LIBS)
+endif
 
 pkgincludedir = $(includedir)/snapper
 


### PR DESCRIPTION
A preview for libbtrfsutil support. Configure-time detection, sample code that's in an ifdef as it does not share much except of function arguments, which would be case for most implemented operations. Before implementing the rest I'd need feedback if this the way to do it or feel free to use it, the util implementations can be added incrementally.