### PR TITLE
Implement BtrfsUtils::get_subvolume using libbtrfsutil

### DIFF
--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jan 19 12:00:00 PM CET 2023 - David Sterba <dsterba@suse.cz>
+
+- Use libbtrfsutil implementation for BtrfsUtil::get_subvolume
+
+-------------------------------------------------------------------
 Thu Jan 12 12:00:00 PM CET 2023 - David Sterba <dsterba@suse.cz>
 
 - Add build support for libbtrfsutil


### PR DESCRIPTION
The helper from btrfs_subvolid_resolve from libbtrfs can be reimplemented by means of libbtrfsutil. btrfs_util_subvolume_path_fd is practically equivalent to btrfs_subvolid_resolve i.e. requires the privileged ioctl. There's another way available to all users but is slow as it needs to iterate overall subvolumes. This is implemented as fallback.