### PR TITLE
- avoid stale btrfs qgroups on transactional systems (bsc#1210151)

### DIFF
--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Apr 13 09:25:42 CEST 2023 - aschnell@suse.com
+
+- avoid stale btrfs qgroups on transactional systems (bsc#1210151)
+
+-------------------------------------------------------------------
 Wed Apr 12 13:32:34 CEST 2023 - aschnell@suse.com
 
 - fixed error message (gh#openSUSE/snapper#801)

--- a/snapper/Btrfs.cc
+++ b/snapper/Btrfs.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2011-2015] Novell, Inc.
- * Copyright (c) [2016-2020] SUSE LLC
+ * Copyright (c) [2016-2023] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -420,13 +420,13 @@ namespace snapper
 
 	    try
 	    {
-		SDir subvolume_dir = openSubvolumeDir();
-		qgroup_destroy(subvolume_dir.fd(), calc_qgroup(0, subvolid));
+		SDir general_dir = openGeneralDir();
+		qgroup_destroy(general_dir.fd(), calc_qgroup(0, subvolid));
 	    }
 	    catch (const runtime_error& e)
 	    {
 		// Ignore that the qgroup could not be destroyed. Should not
-		// cause problems except of having unused qgroups.
+		// cause problems except of having stale qgroups.
 	    }
 
 #endif


### PR DESCRIPTION
For https://bugzilla.suse.com/show_bug.cgi?id=1210151.