### PR TITLE
Implement BtrfsUtils::get_id using libbtrfsutil

### DIFF
--- a/snapper/Btrfs.cc
+++ b/snapper/Btrfs.cc
@@ -402,13 +402,13 @@ namespace snapper
 
 	try
 	{
-#ifdef HAVE_LIBBTRFS
+#if defined(HAVE_LIBBTRFS) || defined(HAVE_LIBBTRFSUTIL)
 	    subvolid_t subvolid = get_id(openSnapshotDir(num).fd());
 #endif
 
 	    delete_subvolume(info_dir.fd(), "snapshot");
 
-#ifdef HAVE_LIBBTRFS
+#if defined(HAVE_LIBBTRFS) || defined(HAVE_LIBBTRFSUTIL)
 	    deleted_subvolids.push_back(subvolid);
 #endif
 

--- a/snapper/BtrfsUtils.cc
+++ b/snapper/BtrfsUtils.cc
@@ -362,9 +362,20 @@ namespace snapper
 
 #endif
 
+#ifdef HAVE_LIBBTRFSUTIL
+	subvolid_t
+	get_id(int fd)
+	{
+	    enum btrfs_util_error err;
+	    subvolid_t id;
 
-#ifdef HAVE_LIBBTRFS
+	    err = btrfs_util_subvolume_id_fd(fd, &id);
+	    if (err)
+		throw runtime_error_with_errno("btrfs_util_subvolume_id_fd() failed", errno);
 
+	    return id;
+	}
+#elif defined(HAVE_LIBBTRFS)
 	subvolid_t
 	get_id(int fd)
 	{
@@ -378,8 +389,10 @@ namespace snapper
 
 	    return args.treeid;
 	}
+#endif
 
 
+#ifdef HAVE_LIBBTRFS
 	bool
 	does_subvolume_exist(int fd, subvolid_t subvolid)
 	{


### PR DESCRIPTION
The get_id() member can be also implemented using libbtrfsutil. A separate conditional implementation is added and the #ifdefs updated that into account.