### PR TITLE
Update useradd script to prevent warnings

### DIFF
--- a/scripts/pam_snapper_useradd.sh
+++ b/scripts/pam_snapper_useradd.sh
@@ -14,13 +14,15 @@ CMD_SNAPPER="/usr/bin/snapper"
 CMD_EGREP="grep -E"
 CMD_PAM_CONFIG="/usr/sbin/pam-config"
 CMD_SED="sed"
-CMD_USERADD="useradd -m"
+CMD_USERADD="useradd"
 CMD_USERDEL="userdel -r"
 CMD_CHOWN="chown"
 CMD_CHMOD="chmod"
+CMD_CPA="cp -a"
 #
 SNAPPERCFGDIR="/etc/snapper/configs"
 HOMEHOME=/home
+SKELLDIR=/etc/skel
 DRYRUN=1
 MYUSER=$1
 MYGROUP=$2
@@ -48,10 +50,12 @@ if [ ${DRYRUN} == 0 ] ; then
 	${CMD_SED} -i -e "s/ALLOW_USERS=\"\"/ALLOW_USERS=\"${MYUSER}\"/g" ${SNAPPERCFGDIR}/home_${MYUSER}
 	# Create USER
 	${CMD_USERADD} ${MYUSER}
+	# Give USER skeleton files
+	${CMD_CPA} ${SKELLDIR}/. ${HOMEHOME}/${MYUSER}
 	# yast users add username=${MYUSER} home=/home/${MYUSER} password=""
 	# !! IMPORTANT !!
 	# chown USER's home directory
-	${CMD_CHOWN} ${MYUSER}.${MYGROUP} ${HOMEHOME}/${MYUSER}
+	${CMD_CHOWN} ${MYUSER}:${MYGROUP} ${HOMEHOME}/${MYUSER}
 	${CMD_CHMOD} 755 ${HOMEHOME}/${MYUSER}/.snapshots
 else
 	echo -e "#"


### PR DESCRIPTION
Not sure if this script is still recommended to use as it's not been modified in nearly a decade.

1. Modified the `useradd` command by removing the `-m` option to prevent unnecessary warnings about the home directory already existing. The creation of the home directory is managed separately in this script using Btrfs subvolumes.
   
2. Added a command to copy the standard skeleton files from `/etc/skel` to the new user's home directory, ensuring that new users receive the necessary setup files despite the custom home directory creation process with the `create-config` command.

3. Corrected the `chown` command syntax to use the more modern `:` separator between the user and group names, getting rid of another warning.

I kept the (old school) style as is. Thanks for snapper!