### PR TITLE
fix building with libxml 2.12.0

### DIFF
--- a/snapper/Logger.cc
+++ b/snapper/Logger.cc
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <libxml/tree.h>
+#include <libxml/xmlerror.h>
 #include <string>
 #include <boost/thread.hpp>
 

--- a/snapper/XmlFile.cc
+++ b/snapper/XmlFile.cc
@@ -23,6 +23,7 @@
 
 #include <cstring>
 #include <unistd.h>
+#include <libxml/parser.h>
 
 #include "snapper/Exception.h"
 #include "snapper/XmlFile.h"


### PR DESCRIPTION
Add missing header files requires on build with libxml 2.12.0.
Fixes #848