### PR TITLE
- async cleanup of stale btrfs qgroups (bsc#1222847)

### DIFF
--- a/client/systemd-helper.cc
+++ b/client/systemd-helper.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) [2016-2023] SUSE LLC
+ * Copyright (c) [2016-2024] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -25,6 +25,9 @@
 
 #include <cstdlib>
 #include <iostream>
+
+#include <snapper/SystemCmd.h>
+#include <snapper/SnapperDefines.h>
 
 #include "utils/text.h"
 #include "utils/GetOpts.h"
@@ -167,6 +170,20 @@ cleanup(ProxySnappers* snappers)
 	    {
 		cerr << "empty-pre-post cleanup for " << value.first << " failed." << endl;
 		ok = false;
+	    }
+	}
+
+	string fstype;
+	if (proxy_config.getValue(KEY_FSTYPE, fstype) && fstype == "btrfs")
+	{
+	    string subvolume;
+	    if (proxy_config.getValue(KEY_SUBVOLUME, subvolume))
+	    {
+		cout << "Running 'btrfs qgroup clear-stale " << subvolume << "'." << endl;
+
+		SystemCmd cmd({ BTRFS_BIN, "qgroup", "clear-stale", subvolume });
+		if (cmd.retcode() != 0)
+		    cerr << "'btrfs qgroup clear-stale " << subvolume << "' failed." << endl;
 	    }
 	}
     }

--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Apr 18 15:03:31 CEST 2024 - aschnell@suse.com
+
+- async cleanup of stale btrfs qgroups (bsc#1222847)
+
+-------------------------------------------------------------------
 Wed Apr 17 17:03:40 CEST 2024 - aschnell@suse.com
 
 - reverted some parts of PR#884 to fix build in obs

--- a/snapper/Btrfs.cc
+++ b/snapper/Btrfs.cc
@@ -424,25 +424,6 @@ namespace snapper
 #if defined(HAVE_LIBBTRFS) || defined(HAVE_LIBBTRFSUTIL)
 	    deleted_subvolids.push_back(subvolid);
 #endif
-
-#ifdef ENABLE_BTRFS_QUOTA
-
-	    // workaround for the kernel not deleting the qgroup of a
-	    // subvolume when deleting the subvolume, see
-	    // https://bugzilla.suse.com/show_bug.cgi?id=972511
-
-	    try
-	    {
-		SDir general_dir = openGeneralDir();
-		qgroup_destroy(general_dir.fd(), calc_qgroup(0, subvolid));
-	    }
-	    catch (const runtime_error& e)
-	    {
-		// Ignore that the qgroup could not be destroyed. Should not
-		// cause problems except of having stale qgroups.
-	    }
-
-#endif
 	}
 	catch (const runtime_error& e)
 	{

--- a/snapper/SnapperDefines.h
+++ b/snapper/SnapperDefines.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2004-2014] Novell, Inc.
- * Copyright (c) [2020-2023] SUSE LLC
+ * Copyright (c) [2020-2024] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -46,6 +46,8 @@
 // commands
 
 #define SH_BIN "/bin/sh"
+
+#define BTRFS_BIN "/usr/sbin/btrfs"
 
 #define SYSTEMCTL_BIN "/usr/bin/systemctl"
 


### PR DESCRIPTION
See https://bugzilla.suse.com/show_bug.cgi?id=1222847.