### PR TITLE
- support creating empty snapshots

### DIFF
--- a/client/snapper/cmd-create.cc
+++ b/client/snapper/cmd-create.cc
@@ -56,7 +56,8 @@ namespace snapper
 	    { _("--command <command>"), _("Run command and create pre and post snapshots.")},
 	    { _("--read-only"), _("Create read-only snapshot.") },
 	    { _("--read-write"), _("Create read-write snapshot.") },
-	    { _("--from <number>"), _("Create a snapshot from the specified snapshot.") }
+	    { _("--from <number>"), _("Create a snapshot from the specified snapshot.") },
+	    { _("--empty"), _("Create an empty snapshot.") }
 	});
     }
 
@@ -83,7 +84,8 @@ namespace snapper
 	    Option("command",			required_argument),
 	    Option("read-only",			no_argument),
 	    Option("read-write",		no_argument),
-	    Option("from",			required_argument)
+	    Option("from",			required_argument),
+	    Option("empty",			no_argument)
 	};
 
 	ParsedOpts opts = get_opts.parse("create", options);
@@ -139,6 +141,9 @@ namespace snapper
 
 	if ((opt = opts.find("from")) != opts.end())
 	    parent = snapshots.findNum(opt->second);
+
+	if ((opt = opts.find("empty")) != opts.end())
+	    scd.empty = true;
 
 	if (type == CreateType::POST && snapshot1 == snapshots.end())
 	{

--- a/doc/snapper.xml.in
+++ b/doc/snapper.xml.in
@@ -2,13 +2,13 @@
 <refentry id='snapper8' xmlns:xlink="http://www.w3.org/1999/xlink">
 
   <refentryinfo>
-    <date>2024-04-18</date>
+    <date>2024-10-24</date>
   </refentryinfo>
 
   <refmeta>
     <refentrytitle>snapper</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='date'>2024-04-18</refmiscinfo>
+    <refmiscinfo class='date'>2024-10-24</refmiscinfo>
     <refmiscinfo class='version'>@VERSION@</refmiscinfo>
     <refmiscinfo class='manual'>Filesystem Snapshot Management</refmiscinfo>
   </refmeta>
@@ -548,6 +548,13 @@
 	      <listitem>
 		<para>Create a snapshot from the snapshot with the
 		provided number instead of snapshot 0.</para>
+	      </listitem>
+	    </varlistentry>
+	    <varlistentry>
+	      <term><option>--empty</option></term>
+	      <listitem>
+		<para>Create an empty snapshot. Only supported on
+		btrfs and with --no-dbus.</para>
 	      </listitem>
 	    </varlistentry>
 	  </variablelist>

--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Oct 25 08:48:46 CEST 2024 - aschnell@suse.com
+
+- support creating empty snapshots (gh#openSUSE/snapper#944)
+
+-------------------------------------------------------------------
 Fri Oct 11 10:34:42 CEST 2024 - aschnell@suse.com
 
 - generate dsc file for Ubuntu 24.10

--- a/snapper/Snapshot.cc
+++ b/snapper/Snapshot.cc
@@ -698,7 +698,7 @@ namespace snapper
 	snapshot.cleanup = scd.cleanup;
 	snapshot.userdata = scd.userdata;
 
-	return createHelper(snapshot, parent, false, report);
+	return createHelper(snapshot, parent, scd.empty, report);
     }
 
 


### PR DESCRIPTION
Add option --empty to snapper cli to allow creating empty snapshots (so subvolumes). See https://github.com/openSUSE/snapper/issues/944 for use-case.