### PR TITLE
doc: clarify SPACE_LIMIT and FREE_LIMIT descriptions in man page #ieeesoc #fixes 967

### DIFF
--- a/doc/snapper-configs.xml.in
+++ b/doc/snapper-configs.xml.in
@@ -60,29 +60,23 @@
 	</listitem>
       </varlistentry>
 
-      <varlistentry>
-	<term><option>SPACE_LIMIT=<replaceable>float</replaceable> or
+      <varlistentry>	<term><option>SPACE_LIMIT=<replaceable>float</replaceable> or
 	<replaceable>size</replaceable></option></term>
 	<listitem>
-	  <para>Limit of the filesystems space the snapshots should
-	  use. Either a fraction of the whole filesystem or an
-	  absolute value. An absolute value must use the C locale.</para>
+	  <para>Threshold for the maximum space snapshots should use on the filesystem. When snapshots exceed this limit (either as a fraction of the whole filesystem or an absolute value), snapper will remove older snapshots during cleanup operations. An absolute value must use the C locale.</para>
 	  <para>Only supported for btrfs.</para>
-	  <para>Default value is &quot;0.5&quot;.</para>
+	  <para>Default value is &quot;0.5&quot; (50% of the filesystem).</para>
 	  <para>New in version 0.3.0, absolute value new in version
 	  0.9.0.</para>
 	</listitem>
       </varlistentry>
 
-      <varlistentry>
-	<term><option>FREE_LIMIT=<replaceable>float</replaceable> or
+      <varlistentry>	<term><option>FREE_LIMIT=<replaceable>float</replaceable> or
 	<replaceable>size</replaceable></option></term>
 	<listitem>
-	  <para>Limit of the filesystem space that should be
-	  free. Either a fraction of the whole filesystem or an absolute
-	  value. An absolute value must use the C locale.</para>
+	  <para>Threshold for the minimum free space that should remain on the filesystem. When free space falls below this limit (either as a fraction of the whole filesystem or an absolute value), snapper will remove older snapshots during cleanup operations to reclaim space. An absolute value must use the C locale.</para>
 	  <para>Only supported for btrfs.</para>
-	  <para>Default value is &quot;0.2&quot;.</para>
+	  <para>Default value is &quot;0.2&quot; (20% of the filesystem).</para>
 	  <para>New in version 0.8.0, absolute value new in version 0.9.0.</para>
 	</listitem>
       </varlistentry>


### PR DESCRIPTION
### **These updates address the specific concerns raised in issue #967:**

Clarify what happens when the SPACE_LIMIT is reached
Explain what happens when free space is below FREE_LIMIT
Make the descriptions more explicit about the thresholds being triggers for cleanup actions

