### PR TITLE
Fix timer description to match actual hourly cleanup frequency

### DIFF
--- a/data/cleanup.timer
+++ b/data/cleanup.timer
@@ -1,6 +1,6 @@
 
 [Unit]
-Description=Daily Cleanup of Snapper Snapshots
+Description=Hourly Cleanup of Snapper Snapshots
 Documentation=man:snapper(8) man:snapper-configs(5)
 
 [Timer]


### PR DESCRIPTION
The snapper-cleanup.timer runs the cleanup every hour (set by OnUnitActiveSec=1h). But its description says "Daily Cleanup of Snapper Snapshots," 

This can confuse people who use snapper for the first time and see the timer status. They might think cleanup only happens once a day.