### PR TITLE
service: add CAP_SYS_CHROOT for sdbootutil

### DIFF
--- a/data/backup.service
+++ b/data/backup.service
@@ -8,7 +8,7 @@ Type=simple
 WorkingDirectory=/root
 ExecStart=/usr/sbin/snbk --verbose --automatic transfer-and-delete
 
-CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_SYS_ADMIN CAP_SYS_MODULE CAP_IPC_LOCK CAP_SYS_NICE
+CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_SYS_ADMIN CAP_SYS_MODULE CAP_IPC_LOCK CAP_SYS_NICE CAP_SYS_CHROOT
 LockPersonality=true
 NoNewPrivileges=false
 ProtectHostname=true

--- a/data/boot.service
+++ b/data/boot.service
@@ -7,7 +7,7 @@ After=nss-user-lookup.target
 Type=oneshot
 ExecStart=/usr/bin/snapper --config root create --cleanup-algorithm number --description "boot"
 
-CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_SYS_ADMIN CAP_SYS_MODULE CAP_IPC_LOCK CAP_SYS_NICE
+CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_SYS_ADMIN CAP_SYS_MODULE CAP_IPC_LOCK CAP_SYS_NICE CAP_SYS_CHROOT
 LockPersonality=true
 NoNewPrivileges=false
 PrivateNetwork=true

--- a/data/cleanup.service
+++ b/data/cleanup.service
@@ -9,7 +9,7 @@ ExecStart=/usr/lib/snapper/systemd-helper --cleanup
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle
 
-CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_SYS_ADMIN CAP_SYS_MODULE CAP_IPC_LOCK CAP_SYS_NICE
+CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_SYS_ADMIN CAP_SYS_MODULE CAP_IPC_LOCK CAP_SYS_NICE CAP_SYS_CHROOT
 LockPersonality=true
 NoNewPrivileges=false
 PrivateNetwork=true

--- a/data/snapperd.service
+++ b/data/snapperd.service
@@ -7,7 +7,7 @@ Type=dbus
 BusName=org.opensuse.Snapper
 ExecStart=/usr/sbin/snapperd
 
-CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_SYS_ADMIN CAP_SYS_MODULE CAP_IPC_LOCK CAP_SYS_NICE
+CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_SYS_ADMIN CAP_SYS_MODULE CAP_IPC_LOCK CAP_SYS_NICE CAP_SYS_CHROOT
 LockPersonality=true
 NoNewPrivileges=false
 PrivateNetwork=true

--- a/data/systemd-sandboxing.txt
+++ b/data/systemd-sandboxing.txt
@@ -25,7 +25,10 @@ CapabilityBoundingSet=CAP_FOWNER is needed if for home directories.
 CapabilityBoundingSet=CAP_DAC_OVERRIDE is needed for directory
 comparison (in some cases) - but not if using btrfs send/receive.
 
-Finally do not forget the plugins.
+Finally do not forget the plugins:
+
+CapabilityBoundingSet=CAP_SYS_CHROOT is required by sdbootutil plugin
+when a new initrd is required, calling dracut via a chroot.
 
 Have a lot of fun...
 

--- a/data/timeline.service
+++ b/data/timeline.service
@@ -7,7 +7,7 @@ After=nss-user-lookup.target
 Type=simple
 ExecStart=/usr/lib/snapper/systemd-helper --timeline
 
-CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_SYS_ADMIN CAP_SYS_MODULE CAP_IPC_LOCK CAP_SYS_NICE
+CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_SYS_ADMIN CAP_SYS_MODULE CAP_IPC_LOCK CAP_SYS_NICE CAP_SYS_CHROOT
 LockPersonality=true
 NoNewPrivileges=false
 PrivateNetwork=true


### PR DESCRIPTION
The snapper plugin from sdbootutil can create initrds when new boot entries are added.  The current implementation is using chroot instead of the --sysroot parameter, as is considered more error-prone.

This patch add the CAP_SYS_CHROOT capability to allow the creation of chroots when new initrds are required.