### PR TITLE
Unify snbk snapshot transfer and restore

### DIFF
--- a/client/snbk/TheBigThing.h
+++ b/client/snbk/TheBigThing.h
@@ -55,6 +55,31 @@ namespace snapper
 	enum class SourceState { MISSING, READ_ONLY, READ_WRITE };
 	enum class TargetState { MISSING, VALID, INVALID };
 
+	TheBigThing(unsigned int num) : num(num) {}
+
+	void transfer(const BackupConfig& backup_config, TheBigThings& the_big_things, bool quiet);
+	void restore(const BackupConfig& backup_config, TheBigThings& the_big_things, bool quiet);
+
+	void remove(const BackupConfig& backup_config, bool quiet);
+
+	unsigned int num;
+	time_t date = 0;	// as reported by snapper
+
+	SourceState source_state = SourceState::MISSING;
+	TargetState target_state = TargetState::MISSING;
+
+	string source_uuid;
+	string source_parent_uuid;
+	string source_received_uuid;
+	string source_creation_time;
+
+	string target_uuid;
+	string target_parent_uuid;
+	string target_received_uuid;
+	string target_creation_time;
+
+    private:
+
 	/** Snapshot copy mode. */
 	enum class CopyMode
 	{
@@ -80,15 +105,6 @@ namespace snapper
 	    string parent_subvol_path;
 	};
 
-	TheBigThing(unsigned int num) : num(num) {}
-
-	void copy(const BackupConfig& backup_config, TheBigThings& the_big_things,
-	          const pair<CopySpec, CopySpec>& copy_specs);
-	void transfer(const BackupConfig& backup_config, TheBigThings& the_big_things, bool quiet);
-	void restore(const BackupConfig& backup_config, TheBigThings& the_big_things, bool quiet);
-
-	void remove(const BackupConfig& backup_config, bool quiet);
-
 	/**
 	 * Create specifications for the copy source and the copy destination according to
 	 * the specified `copy_mode`. The function returns a pair containing the source
@@ -98,24 +114,8 @@ namespace snapper
 	make_copy_specs(const BackupConfig& backup_config,
 	                const TheBigThings& the_big_things, CopyMode copy_mode) const;
 
-	string source_snapshot_dir(const BackupConfig& backup_config) const;
-	string target_snapshot_dir(const BackupConfig& backup_config) const;
-
-	unsigned int num;
-	time_t date = 0;	// as reported by snapper
-
-	SourceState source_state = SourceState::MISSING;
-	TargetState target_state = TargetState::MISSING;
-
-	string source_uuid;
-	string source_parent_uuid;
-	string source_received_uuid;
-	string source_creation_time;
-
-	string target_uuid;
-	string target_parent_uuid;
-	string target_received_uuid;
-	string target_creation_time;
+	void copy(const BackupConfig& backup_config, TheBigThings& the_big_things,
+	          const pair<CopySpec, CopySpec>& copy_specs);
 
     };
 


### PR DESCRIPTION
The pull request proposes two implementation unifications for snbk:

* Unification of `TheBigThing::transfer` and `TheBigThing::restore` (41372b86b8bda78f78a71316eeb6c1227923dd75).
* ~Unification of the `transfer`, `restore`, and `delete` commands (65f2e7ec37b626fefaa5035c3132fb5a358f1c43).~ (moving to another PR)

### Unification of `TheBigThing::transfer` and `TheBigThing::restore`

The Btrfs send parent finding algorithm used by both snapshot transfer and restore was unified in a previous PR (#1080).
Technically, the transfer and restore procedures are now identical. The only difference between them is the roles of the sender and receiver.

The unification is achieved by introducing the `TheBigThing::copy` function.
The transfer implementation is replaced by copying the snapshot from the source to the target, while the restore implementation is replaced by copying the snapshot from the target back to the source.

### ~Unification of transfer, restore, and delete commands~

~Currently, the transfer, restore, and delete commands follow the same procedure. A `snapshot_operation` function has been added to the utils module, along with a `SnapshotOperationCustomizer` base class to customize command-specific behavior and messages.~

~I’m not sure if you will like this unification or not. It does not reduce much code. It enforces a consistent procedure across the transfer, restore, and delete commands. Changes to the operation implementation automatically apply to all derived commands. However, if these commands diverge further in the future, the complexity of the operation implementation may increase.~