### PR TITLE
Prevent manually transferring a read‑write snapshot

### DIFF
--- a/client/snbk/TheBigThing.cc
+++ b/client/snbk/TheBigThing.cc
@@ -250,6 +250,8 @@ namespace snapper
 
 	if (source_state == SourceState::MISSING)
 	    SN_THROW(Exception(_("Snapshot not on source.")));
+	else if (source_state == SourceState::READ_WRITE)
+	    SN_THROW(Exception(_("Cannot transfer a read-write snapshot.")));
 
 	if (target_state != TargetState::MISSING)
 	    SN_THROW(Exception(_("Snapshot already on target.")));


### PR DESCRIPTION
This pull request adds a check in `TheBigThing::restore`.
The check prevents `snbk` from creating an invalid snapshot on the target device when a user manually transfers a read-write snapshot.