### PR TITLE
snbk: Remove source-path from backup config

### DIFF
--- a/client/snbk/BackupConfig.cc
+++ b/client/snbk/BackupConfig.cc
@@ -52,9 +52,6 @@ namespace snapper
 	if (!toValue(tmp1, target_mode, false))
 	    SN_THROW(Exception(sformat("unknown target-mode '%s' in '%s'", tmp1.c_str(), name.c_str())));
 
-	if (!get_child_value(json_file.get_root(), "source-path", source_path))
-	    SN_THROW(Exception(sformat("source-path entry not found in '%s'", name.c_str())));
-
 	if (!get_child_value(json_file.get_root(), "target-path", target_path))
 	    SN_THROW(Exception(sformat("target-path entry not found in '%s'", name.c_str())));
 

--- a/client/snbk/BackupConfig.h
+++ b/client/snbk/BackupConfig.h
@@ -57,7 +57,6 @@ namespace snapper
 
 	TargetMode target_mode = TargetMode::LOCAL;
 
-	string source_path;
 	string target_path;
 
 	bool automatic = false;

--- a/client/snbk/TheBigThing.h
+++ b/client/snbk/TheBigThing.h
@@ -163,9 +163,10 @@ namespace snapper
 	TreeView source_tree;
 	TreeView target_tree;
 
+	const ProxySnapper* snapper;
+
     private:
 
-	const ProxySnapper* snapper;
 	const Locker locker;
 
 	vector<TheBigThing> the_big_things;

--- a/client/snbk/cmd-list-configs.cc
+++ b/client/snbk/cmd-list-configs.cc
@@ -53,7 +53,7 @@ namespace snapper
 
 	enum class Column
 	{
-	    NAME, CONFIG, TARGET_MODE, AUTOMATIC, SOURCE_PATH, TARGET_PATH, SSH_HOST,
+	    NAME, CONFIG, TARGET_MODE, AUTOMATIC, TARGET_PATH, SSH_HOST,
 	    SSH_USER, SSH_PORT, SSH_IDENTITY, TARGET_BTRFS_BIN, TARGET_LS_BIN,
 	    TARGET_MKDIR_BIN, TARGET_RM_BIN, TARGET_RMDIR_BIN
 	};
@@ -75,9 +75,6 @@ namespace snapper
 
 		case Column::AUTOMATIC:
 		    return Cell(_("Automatic"));
-
-		case Column::SOURCE_PATH:
-		    return Cell(_("Source Path"));
 
 		case Column::TARGET_PATH:
 		    return Cell(_("Target Path"));
@@ -131,9 +128,6 @@ namespace snapper
 
 		case Column::AUTOMATIC:
 		    return backup_config.automatic;
-
-		case Column::SOURCE_PATH:
-		    return backup_config.source_path;
 
 		case Column::TARGET_PATH:
 		    return backup_config.target_path;
@@ -290,11 +284,11 @@ namespace snapper
 	}
 
 	const vector<Column> some_columns = { Column::NAME, Column::CONFIG, Column::TARGET_MODE,
-	    Column::AUTOMATIC, Column::SOURCE_PATH, Column::TARGET_PATH, Column::SSH_HOST,
+	    Column::AUTOMATIC, Column::TARGET_PATH, Column::SSH_HOST,
 	    Column::SSH_USER, Column::SSH_PORT, Column::SSH_IDENTITY };
 
 	const vector<Column> all_columns = { Column::NAME, Column::CONFIG, Column::TARGET_MODE,
-	    Column::AUTOMATIC, Column::SOURCE_PATH, Column::TARGET_PATH, Column::SSH_HOST,
+	    Column::AUTOMATIC, Column::TARGET_PATH, Column::SSH_HOST,
 	    Column::SSH_USER, Column::SSH_PORT, Column::SSH_IDENTITY, Column::TARGET_BTRFS_BIN,
 	    Column::TARGET_LS_BIN, Column::TARGET_MKDIR_BIN, Column::TARGET_RM_BIN,
 	    Column::TARGET_RMDIR_BIN
@@ -320,7 +314,7 @@ namespace snapper
     template <> struct EnumInfo<Column> { static const vector<string> names; };
 
     const vector<string> EnumInfo<Column>::names({
-	"name", "config", "target-mode", "automatic", "source-path", "target-path", "ssh-host",
+	"name", "config", "target-mode", "automatic", "target-path", "ssh-host",
 	"ssh-user", "ssh-port", "ssh-identity", "target-btrfs-bin", "target-ls-bin",
 	"target-mkdir-bin", "target-rm-bin", "target-rmdir-bin"
     });

--- a/client/snbk/cmd-list.cc
+++ b/client/snbk/cmd-list.cc
@@ -232,8 +232,7 @@ namespace snapper
 		if (backup_configs.size() > 1)
 		{
 		    cout << "Backup-config:" << backup_config.name << ", config:" << backup_config.config
-			 << ", source-path:" << backup_config.source_path << ", target-mode:"
-			 << toString(backup_config.target_mode) << endl;
+			 << ", target-mode:" << toString(backup_config.target_mode) << endl;
 		}
 
 		try


### PR DESCRIPTION
This pull request removes the `source-path` field from the `snbk` backup config.

Detailed changes:
- Removed displaying `source-path` from the `snbk list-configs` and `snbk list` commands.
- Removed `source_path` from the `BackupConfig` class.
- Changed the private function `source_snapshot_dir` to derive the source snapshot directory from `ProxySnapper` instead of `BackupConfig`.
- Changed the access level of `TheBigThings::snapper` from private to public. This is required to evaluate the source snapshot directory outside the scope of `TheBigThings`.

resolve #1094 