### PR TITLE
Add `snapper-sync` to synchronize the highest snapshot number

### DIFF
--- a/data/10-snapper-sync-override.conf
+++ b/data/10-snapper-sync-override.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=snapper-sync.service

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,7 +6,7 @@ EXTRA_DIST = sysconfig.snapper base.txt lvm.txt x11.txt snapper.logrotate	\
 	default-config org.opensuse.Snapper.conf org.opensuse.Snapper.service	\
 	zypp-plugin.conf timeline.service timeline.timer cleanup.service	\
 	cleanup.timer boot.service boot.timer backup.service backup.timer	\
-	snapperd.service
+	snapperd.service snapper-sync.service 10-snapper-sync-override.conf
 
 install-data-local:
 	install -D -m 644 snapper.logrotate $(DESTDIR)/etc/logrotate.d/snapper
@@ -38,6 +38,9 @@ if ENABLE_SYSTEMD
 	install -D -m 644 backup.service $(DESTDIR)/usr/lib/systemd/system/snapper-backup.service
 	install -D -m 644 backup.timer $(DESTDIR)/usr/lib/systemd/system/snapper-backup.timer
 	install -D -m 644 snapperd.service $(DESTDIR)/usr/lib/systemd/system/snapperd.service
+	install -D -m 644 snapper-sync.service $(DESTDIR)/usr/lib/systemd/system/snapper-sync.service
+	install -D -m 644 10-snapper-sync-override.conf $(DESTDIR)/usr/lib/systemd/system/snapper-boot.timer.d/10-snapper-sync-override.conf
+	install -D -m 644 10-snapper-sync-override.conf $(DESTDIR)/usr/lib/systemd/system/snapper-timeline.timer.d/10-snapper-sync-override.conf
 endif
 
 if HAVE_ZYPP

--- a/data/snapper-sync.service
+++ b/data/snapper-sync.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Snapper Highest Snapshot Number Synchronization
+Documentation=man:snapper(8)
+After=snapperd.service
+Requires=snapperd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/snapper-sync
+RemainAfterExit=yes
+
+CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_SYS_ADMIN CAP_SYS_MODULE CAP_IPC_LOCK CAP_SYS_NICE CAP_MKNOD
+LockPersonality=true
+NoNewPrivileges=false
+PrivateNetwork=true
+ProtectHostname=true
+RestrictAddressFamilies=AF_UNIX
+RestrictRealtime=true
+
+[Install]
+WantedBy=timers.target

--- a/data/snapper-sync.service
+++ b/data/snapper-sync.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Snapper Highest Snapshot Number Synchronization
-Documentation=man:snapper(8)
+Documentation=man:snbk(8)
 After=snapperd.service
 Requires=snapperd.service
 

--- a/dists/debian/control
+++ b/dists/debian/control
@@ -17,7 +17,7 @@ Package: snapper-backup
 Priority: optional
 Section: admin
 Architecture: any
-Depends: ${shlibs:Depends}
+Depends: ${shlibs:Depends}, jq
 Description: snapper-backup
  This package contains snbk, a tool for backups of snapper snapshots.
 

--- a/dists/debian/snapper-backup.install
+++ b/dists/debian/snapper-backup.install
@@ -2,4 +2,8 @@ etc/snapper/backup-configs
 etc/snapper/certs
 usr/lib/systemd/system/snapper-backup.service
 usr/lib/systemd/system/snapper-backup.timer
+usr/lib/systemd/system/snapper-sync.service
+usr/lib/systemd/system/snapper-boot.timer.d/10-snapper-sync-override.conf
+usr/lib/systemd/system/snapper-timeline.timer.d/10-snapper-sync-override.conf
 usr/sbin/snbk
+usr/sbin/snapper-sync

--- a/doc/snbk.xml.in
+++ b/doc/snbk.xml.in
@@ -2,13 +2,13 @@
 <refentry id='snbk8' xmlns:xlink="http://www.w3.org/1999/xlink">
 
   <refentryinfo>
-    <date>2026-01-16</date>
+    <date>2026-04-23</date>
   </refentryinfo>
 
   <refmeta>
     <refentrytitle>snbk</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='date'>2026-01-16</refmiscinfo>
+    <refmiscinfo class='date'>2026-04-23</refmiscinfo>
     <refmiscinfo class='version'>@VERSION@</refmiscinfo>
     <refmiscinfo class='manual'>Filesystem Snapshot Management</refmiscinfo>
   </refmeta>
@@ -138,6 +138,67 @@
 	restoration. The root node of the diagram is a specialized virtual node, which is
 	not a Btrfs subvolume, representing the Btrfs filesystem on the source or target.
       </para>
+    </refsect2>
+
+    <refsect2 id='snapshot-number-sync'>
+      <title>Highest Snapshot Number Synchronization</title>
+
+      <para>To avoid reusing snapshot numbers, 'snapperd' keeps the highest snapshot
+      folder (whether it is an empty snapshot or not) in <filename>.snapshots</filename>
+      directory, ensuring snapshot numbers remain unique at all times.
+      However, when performing a restore using various methods, the state of the highest
+      snapshot number may vary:</para>
+
+      <itemizedlist>
+	<listitem>
+	  <para>Synchronized: The latest backed-up snapshot is restored to
+	  <filename>.snapshots</filename> using `snbk restore` or manual Btrfs
+	  send-receive.
+	  In this case, the highest snapshot number is synchronized.
+	  'snapperd' creates snapshots with numbers greater than the restored snapshot,
+	  preventing snapshot number collisions.
+	  </para>
+	</listitem>
+	<listitem>
+	  <para>Legacy: A restore is made with a previous but not the latest backed-up
+	  snapshot.
+	  In this case, the state of the highest snapshot number is not valid.
+	  'snapperd' would create snapshots with numbers lower than the latest backed-up
+	  snapshot.
+	  This could invalidate the backed-up snapshots created later than the restored
+	  snapshot, and these invalid backed-up snapshots might be removed during the
+	  automatic Snapper backup process.
+	</para>
+	</listitem>
+	<listitem>
+	  <para>Legacy: When using a virtualization platform and the system is restored
+	  from a virtual machine backup.
+	  In this case, depending on the timing of the VM backup creation, the state of
+	  the highest snapshot number might not be synchronized.
+	  Snapshot number collisions might occur when 'snapperd' creates snapshots after
+	  the VM boots up.
+	  </para>
+	</listitem>
+
+      </itemizedlist>
+
+      <para>To avoid snapshot number collisions, The Snapper Backup package provides a
+      'snapper-sync' script, which can be triggered by `snapper-sync.service`, to
+      synchronize the highest snapshot number across the source and backup target devices.
+      Please consider enabling `snapper-sync.service` if any scenario related to 'Legacy'
+      might occur in your environment.
+
+      If any custom systemd timer or service is configured, please consider adding
+      the following directives:
+
+	<programlisting>
+[Unit]
+After=snapper-sync.service
+	</programlisting>
+
+      This ensures systemd schedules the custom unit to run after the highest snapshot
+      number synchronization.</para>
+
     </refsect2>
 
   </refsect1>

--- a/package/snapper.changes
+++ b/package/snapper.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri 24 Apr 05:05:24 UTC 2026 - Cheng-Ling Lai <jameslai.tech@gmail.com>
+
+- Add snapper-sync to synchronize the highest snapshot number
+  (gh#openSUSE/snapper#1128)
+
+-------------------------------------------------------------------
 Wed Mar 25 15:18:15 CET 2026 - Arvin Schnell <aschnell@suse.com>
 
 - fix deleting LVM configs in case of empty directories

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -4,6 +4,8 @@
 
 SUBDIRS = completion
 
+sbin_SCRIPTS = snapper-sync
+
 if HAVE_PAM
 
 pam_snapperdir = /usr/lib/pam_snapper
@@ -20,4 +22,3 @@ EXTRA_DIST = snapper-hourly snapper-sync $(pam_snapper_SCRIPTS)
 
 install-data-local:
 	install -D snapper-hourly $(DESTDIR)/etc/cron.hourly/suse.de-snapper
-	install -D snapper-sync $(DESTDIR)/usr/sbin

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -16,7 +16,8 @@ pam_snapper_SCRIPTS =			\
 
 endif
 
-EXTRA_DIST = snapper-hourly $(pam_snapper_SCRIPTS)
+EXTRA_DIST = snapper-hourly snapper-sync $(pam_snapper_SCRIPTS)
 
 install-data-local:
 	install -D snapper-hourly $(DESTDIR)/etc/cron.hourly/suse.de-snapper
+	install -D snapper-sync $(DESTDIR)/usr/sbin

--- a/scripts/snapper-sync
+++ b/scripts/snapper-sync
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+set -eu
+
+# Check for the required binaries
+check_binary() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo >&2 "Error: '$1' is required but not found in PATH."
+    exit 1
+  }
+}
+
+check_binary jq
+check_binary mkdir
+check_binary snapper
+check_binary snbk
+
+# Construct a list of dictionaries containing the necessary snapshot information,
+# including the name of the backup-config, the name of the source-config, and the snapshot
+# number
+config_mapping=$(
+  snbk --machine-readable json list-configs |
+  jq -r '."backup-configs" | map({key: .name, value: .config}) | from_entries'
+)
+
+if outputs=$(snbk --machine-readable json list); then
+  snapshots=$(
+    echo $outputs |
+    jq --argjson config_mapping "$config_mapping" '
+      .snapshots | . |= map(. + {config: $config_mapping[.name]})
+    '
+  )
+else
+  echo >&2 "Error: 'snbk list' failed with exit status $?"
+  exit 1
+fi
+
+# Create the snapshot placeholder with the highest number if missing
+echo "$config_mapping" | jq -r 'keys[]' | while read -r backup_config; do
+
+  # Query the name of source-config for the currently processed backup-config
+  source_config=$(echo "$config_mapping" | jq -r ".[\"$backup_config\"]")
+
+  # Query the highest snapshot number across backup-configs with the same source-config
+  max_num=$(
+    echo "$snapshots" |
+    jq -r "[.[] | select(.config == \"$source_config\")] | max_by(.number) | .number"
+  )
+
+  # Query the source subvolume path
+  subvol_path=$(
+    snapper --machine-readable json -c "$source_config" get-config | jq -r '.SUBVOLUME'
+  )
+
+  # Check and make the snapshot placeholder with the highest number
+  target_path="$subvol_path/.snapshots/$max_num"
+  if [ -d "$target_path" ]; then
+    echo "$target_path exists."
+  else
+    mkdir "$target_path"
+    echo "$target_path created."
+  fi
+
+done

--- a/snapper.spec.in
+++ b/snapper.spec.in
@@ -224,7 +224,7 @@ test -f /etc/logrotate.d/snapper.rpmsave && mv -v /etc/logrotate.d/snapper.rpmsa
 %else
 %config(noreplace) %{_sysconfdir}/logrotate.d/snapper
 %endif
-%{_unitdir}/snapper-{timeline,cleanup,boot}.*
+%{_unitdir}/snapper-{timeline,cleanup,boot}.{service,timer}
 %{_unitdir}/snapperd.service
 %if 0%{?suse_version} <= 1500
 %dir %{_datadir}/dbus-1/system.d
@@ -360,6 +360,7 @@ done
 
 %package -n snapper-backup
 Requires:       snapper = %version
+Requires:       jq
 Summary:        A backup program for snapper
 Group:          System/Packages
 Recommends:     %{name}-lang
@@ -369,9 +370,13 @@ A backup program for snapshots created by snapper.
 
 %files -n snapper-backup
 %{_sbindir}/snbk
+%{_sbindir}/snapper-sync
 %dir %{_sysconfdir}/snapper/backup-configs
 %dir %{_sysconfdir}/snapper/certs
 %{_unitdir}/snapper-{backup}.*
+%{_unitdir}/snapper-sync.service
+%{_unitdir}/snapper-boot.timer.d/10-snapper-sync-override.conf
+%{_unitdir}/snapper-timeline.timer.d/10-snapper-sync-override.conf
 %{_mandir}/*/snbk.8*
 %{_mandir}/*/snapper-backup-configs.5*
 %dir %{_datadir}/bash-completion

--- a/snapper.spec.in
+++ b/snapper.spec.in
@@ -375,7 +375,9 @@ A backup program for snapshots created by snapper.
 %dir %{_sysconfdir}/snapper/certs
 %{_unitdir}/snapper-{backup}.*
 %{_unitdir}/snapper-sync.service
+%{_unitdir}/snapper-boot.timer.d
 %{_unitdir}/snapper-boot.timer.d/10-snapper-sync-override.conf
+%{_unitdir}/snapper-timeline.timer.d
 %{_unitdir}/snapper-timeline.timer.d/10-snapper-sync-override.conf
 %{_mandir}/*/snbk.8*
 %{_mandir}/*/snapper-backup-configs.5*


### PR DESCRIPTION
To resolve the potential snapshot number collision after a system restore, as mentioned in <https://github.com/openSUSE/snapper/issues/1105#issuecomment-4221769201>, this pull request adds a `snapper-sync` script to synchronize the highest snapshot number between the source and the backup target. The script can be triggered automatically by enabling `snapper-sync.service`.

Detailed changes:

- Added `script/snapper-sync`: A script to synchronize the highest snapshot number across  `snapperd` and `snbk`. ~~This script does nothing if `snbk` is not installed.~~ The script requires both `snapper` and `snbk` to be installed.
- Added `data/snapper-sync.service`: An optional systemd service to trigger `snapper-sync`  automatically.
- Changed `data/boot.timer` and `data/timeline.timer` to optionally depend on  `snapper-sync.service`.
- Changed `snapper.spec.in` and `dist/debian` to include `snapper-sync` related files in the ~~`snapper`~~ `snapper-backup` package.
- Added documentation for `snapper-sync` in the ~~`snapper`~~ `snapper-backup` manual.