### PR TITLE
Fix ssh option configuration ordering for snbk ssh-push targets

### DIFF
--- a/client/snbk/BackupConfig.cc
+++ b/client/snbk/BackupConfig.cc
@@ -107,7 +107,7 @@ namespace snapper
     vector<string>
     BackupConfig::ssh_options() const
     {
-	vector<string> options = { ssh_host };
+	vector<string> options;
 
 	if (ssh_port != 0)
 	    options.insert(options.end(), { "-p", to_string(ssh_port) });
@@ -121,6 +121,9 @@ namespace snapper
 	if (ssh_master_control)
 	    options.insert(options.end(), { "-o", "ControlMaster=auto", "-o", "ControlPath=\"~/.ssh/snbk-%C\"",
 		"-o", "ControlPersist=30s" });
+
+	// The target host must be the final argument before the command string execution block
+	options.push_back(ssh_host);
 
 	return options;
     }


### PR DESCRIPTION
## Description
This PR fixes an issue within the `snbk` client engine where configured SSH parameters (such as custom ports, identity files, user logins, and control multiplexing options) are mistakenly evaluated as remote commands instead of local execution flags.

---

## Problem
In `client/snbk/BackupConfig.cc`, the `ssh_options()` method constructs the argument vector starting with the target host variable as its very first element:

```cpp
vector<string> options = { ssh_host };
```

When client/snbk/Shell.cc subsequently runs the shell runtime array via ssh <options> <command>, it appends the target command block onto this options array. According to standard OpenSSH syntax rules, any flags positioned after the hostname parameter are interpreted as part of the remote terminal command string rather than local client configurations.

Consequently, parameters like -p, -l, -i, and -o fail to apply to the local SSH session, breaking custom connectivity rules entirely.

## Solution
Modified BackupConfig::ssh_options() to initialize an empty vector, sequentially inject the connection flags first, and append ssh_host as the final parameter of the configuration block. This satisfies standard ssh(1) argument sequencing rules.

## Bug Discovery & Technical Audit Analysis
- Context
While reviewing the snbk push-target ecosystem to map out the execution pipeline of backup synchronization sequences, a manual engineering code inspection was performed across the configuration setup modules (client/snbk/BackupConfig.cc) and shell execution wrapper scopes (client/snbk/Shell.cc).

1. Tracing the Execution Flow: In client/snbk/Shell.cc, the engine compiles and executes an active shell runtime command array structured identically to a standard ssh <options> <command> interface pattern.
2. Identifying the Structural Anomaly: Looking closely at the argument builder inside BackupConfig::ssh_options(), the configuration array was initialized with the target host tracking variable placed at index 0, followed by a sequence of conditional .insert() operations.
3. Root Cause Evaluation: In POSIX and OpenSSH CLI specifications, flags governing transport parameters (such as routing ports via -p, identity credentials via -i, or login aliases via -l) must be parsed prior to parsing the remote host target. Because the initial implementation positioned ssh_host at the absolute front of the vector array, any runtime configuration flag appended subsequently was pushed down into the remote command payload block, completely bypassing the local client configuration parsing sequence.

This configuration sequencing error was caught through structural source code analysis during a proactively scheduled code health audit. The patch cleanly rearranges the vector assembly mechanics to align with proper argument positioning constraints.

