### PR TITLE
Fix: Handle DBus connection failures in cdbus_create_snapshot

### DIFF
--- a/pam/pam_snapper.c
+++ b/pam/pam_snapper.c
@@ -371,6 +371,10 @@ static int cdbus_create_snapshot( const char *snapper_conf, createmode_t createm
 		dbus_error_free( &err );
 	}
 
+        if ( conn == NULL ) {
+        return -EINVAL;
+	}
+
 	DBusMessage *req_msg;
 	int ret = cdbus_create_snap_pack( snapper_conf, createmode, cleanup, num_user_data,
 					  user_data, snapshot_num_in, &req_msg );


### PR DESCRIPTION
<html>
<body>
<h2>Summary</h2>
<p>This patch adds a missing NULL check for the DBus connection handle returned by
<code>dbus_bus_get_private()</code> in <code>cdbus_create_snapshot()</code>. Without this check, a
failed connection silently passes a NULL pointer into subsequent DBus API calls,
leading to undefined behaviour or a crash.</p>
<hr>
<h2>How the Bug Was Found</h2>
<p>While reading through <code>pam/pam_snapper.c</code> to understand how the module
interacts with the snapper DBus interface, I noticed that <code>dbus_bus_get_private()</code>
is called and its error is properly freed, but the return value <code>conn</code> is never
validated before being used.</p>
<p>The DBus documentation states that <code>dbus_bus_get_private()</code> can return <code>NULL</code>
when the connection cannot be established (for example, when the system bus is
unavailable, the user lacks permissions, or snapperd is not running). In that
situation, every subsequent call that receives <code>conn</code> as an argument is operating
on a NULL pointer:</p>
<ul>
<li><code>cdbus_msg_send()</code> passes <code>conn</code> to <code>dbus_connection_send_with_reply()</code> and
<code>dbus_connection_flush()</code></li>
<li>The cleanup path calls <code>dbus_connection_close( conn )</code> and
<code>dbus_connection_unref( conn )</code></li>
</ul>
<p>All of these will dereference NULL, which is undefined behaviour and will likely
segfault in practice.</p>
<hr>
<h2>Root Cause</h2>
<pre><code class="language-c">/* pam/pam_snapper.c — before this patch */

DBusConnection *conn = dbus_bus_get_private( DBUS_BUS_SYSTEM, &amp;err );
if ( dbus_error_is_set( &amp;err ) ) {
        dbus_error_free( &amp;err );
}

/* conn is used here without any NULL check */
DBusMessage *req_msg;
int ret = cdbus_create_snap_pack( ... );
</code></pre>
<p><code>dbus_bus_get_private()</code> returns <code>NULL</code> on failure. The error flag is cleared
correctly, but the function never returns early when <code>conn == NULL</code>. Everything
after that line assumes <code>conn</code> is valid.</p>
<hr>
<h2>Fix</h2>
<p>Add a NULL check immediately after the error handling block, before any use of
<code>conn</code>:</p>
<pre><code class="language-c">DBusConnection *conn = dbus_bus_get_private( DBUS_BUS_SYSTEM, &amp;err );
if ( dbus_error_is_set( &amp;err ) ) {
        dbus_error_free( &amp;err );
}

if ( conn == NULL ) {
        return -EINVAL;
}
</code></pre>
<p>This ensures the function exits cleanly with an error code instead of
proceeding with a NULL connection handle.</p>

</body>
</html>