### PR TITLE
Release parsed zypp JSON objects

### DIFF
--- a/zypp-plugin/snapper-zypp-plugin.cc
+++ b/zypp-plugin/snapper-zypp-plugin.cc
@@ -356,51 +356,52 @@ SnapperZyppCommitPlugin::get_solvables(const Message& msg, Phase phase) const
     // {"TransactionStepList":[{"type":"?","stage":"?","solvable":{"n":"mypackage"}}]}
     // https://doc.opensuse.org/projects/libzypp/SLE12SP2/plugin-commit.html
     json_object* steps = object_get(zypp, "TransactionStepList");
-    if (!steps)
-	return result;
-
-    if (json_object_get_type(steps) == json_type_array)
+    if (steps)
     {
-	size_t len = json_object_array_length(steps);
-	for (size_t i = 0; i < len; ++i)
+	if (json_object_get_type(steps) == json_type_array)
 	{
-	    json_object* step = json_object_array_get_idx(steps, i);
-	    bool have_type = json_object_object_get_ex(step, "type", NULL);
-	    bool have_stage = json_object_object_get_ex(step, "stage", NULL);
-	    if (have_type && (phase == Phase::BEFORE || have_stage))
+	    size_t len = json_object_array_length(steps);
+	    for (size_t i = 0; i < len; ++i)
 	    {
-		json_object* solvable = object_get(step, "solvable");
-		if (!solvable)
+		json_object* step = json_object_array_get_idx(steps, i);
+		bool have_type = json_object_object_get_ex(step, "type", NULL);
+		bool have_stage = json_object_object_get_ex(step, "stage", NULL);
+		if (have_type && (phase == Phase::BEFORE || have_stage))
 		{
-		    y2err("in item #" << i);
-		    continue;
-		}
+		    json_object* solvable = object_get(step, "solvable");
+		    if (!solvable)
+		    {
+			y2err("in item #" << i);
+			continue;
+		    }
 
-		json_object* name = object_get(solvable, "n");
-		if (!name)
-		{
-		    y2err("in item #" << i);
-		    continue;
-		}
+		    json_object* name = object_get(solvable, "n");
+		    if (!name)
+		    {
+			y2err("in item #" << i);
+			continue;
+		    }
 
-		if (json_object_get_type(name) != json_type_string)
-		{
-		    y2err("\"n\" is not a string");
-		    y2err("in item #" << i);
-		    continue;
-		}
-		else
-		{
-		    const char* prize = json_object_get_string(name);
-		    result.insert(prize);
+		    if (json_object_get_type(name) != json_type_string)
+		    {
+			y2err("\"n\" is not a string");
+			y2err("in item #" << i);
+			continue;
+		    }
+		    else
+		    {
+			const char* prize = json_object_get_string(name);
+			result.insert(prize);
+		    }
 		}
 	    }
 	}
     }
 
+    json_object_put(zypp);
+
     return result;
 }
-
 
 void
 SnapperZyppCommitPlugin::match_solvables(const set<string>& solvables, bool& found, bool& important) const

--- a/zypp-plugin/snapper-zypp-plugin.cc
+++ b/zypp-plugin/snapper-zypp-plugin.cc
@@ -403,6 +403,7 @@ SnapperZyppCommitPlugin::get_solvables(const Message& msg, Phase phase) const
     return result;
 }
 
+
 void
 SnapperZyppCommitPlugin::match_solvables(const set<string>& solvables, bool& found, bool& important) const
 {


### PR DESCRIPTION
## Description
This pull request fixes a memory leak in the snapper zypp plugin. The function responsible for extracting solvable package entries from incoming zypp message payloads parses JSON text into an in-memory object tree but fails to release the allocated memory before returning.

## Problem
In `zypp-plugin/snapper-zypp-plugin.cc`, the method `SnapperZyppCommitPlugin::get_solvables` handles JSON payload translation. It invokes `json_tokener_parse_ex` to build a root `json_object` node tree. 

While the surrounding `JsonTokener` class relies on its RAII destructor to cleanly free the underlying parsing mechanism wrapper, the generated `json_object` tree itself operates on reference counting. Because no execution paths ever trigger a balancing `json_object_put(zypp)` call, the parsed structures are leaked on every payload processing evaluation.

## Solution
Modified the control flow within `get_solvables` to safely handle lifecycle cleanups:
- Removed the raw early-exit return (`if (!steps) return result;`) that bypassed cleanup.
- Wrapped the array extraction logic inside a safe, nested conditional check (`if (steps)`), forcing execution to collapse to the baseline of the function under all runtime circumstances.
- Added a explicit `json_object_put(zypp);` statement immediately before returning the final package result set to release the heap allocation.

## How I Found It
While reviewing the plugin source file to analyze payload transaction tracking and memory profile footprint structures, I observed a structural discrepancy. The token parsing lifecycle implementation ensures structural parsing structures balance out, but the generation layer completely omitted the mandatory reference release step defined by the json-c memory usage interface guidelines.