### PR TITLE
Validate unsigned integer JSON config values

### DIFF
--- a/client/snbk/JsonFile.cc
+++ b/client/snbk/JsonFile.cc
@@ -24,6 +24,7 @@
 #include <sys/stat.h>
 #include <functional>
 #include <memory>
+#include <limits>
 
 #include "snapper/Exception.h"
 #include "snapper/AppUtil.h"
@@ -181,7 +182,13 @@ namespace snapper
 	if (!json_object_is_type(child, json_type_int) && !json_object_is_type(child, json_type_string))
 	    return false;
 
-	value = json_object_get_int(child);
+	int64_t val64 = json_object_get_int64(child);
+	if (val64 < 0 || val64 > std::numeric_limits<unsigned int>::max())
+	{
+	    SN_THROW(Exception(sformat("Value out of bounds for unsigned int key '%s'", name)));
+	}
+
+	value = (unsigned int)val64;
 
 	return true;
     }


### PR DESCRIPTION
## Description
This pull request introduces explicit bounds checking for unsigned configuration fields parsed via the `snbk` JSON parsing backend. It ensures that values intended for unsigned targets (such as `ssh-port`) are not silently truncated or wrapped due to overflowing or negative integer representations within the raw configuration payload.

## Problem
In `client/snbk/JsonFile.cc`, the translation interface parses numeric configuration variables directly via `json_object_get_int()` and assigns them blindly to unsigned internal targets. 

When an invalid or malicious configuration specifies an out-of-range value or a negative number (e.g., `-1`), the underflow/overflow behaviors wrap the integer data into massive unexpected values. When propagated up through `client/snbk/BackupConfig.cc` to initialize settings like network port structures, this creates corrupted network configurations and unpredictable connection faults rather than throwing an explicit configuration error.

## Solution
Implemented rigorous validation handling for unsigned integers during config key extraction inside `JsonFile.cc`:
- Inspected the extracted JSON numeric object value using a localized validation mechanism before passing it down to data consumers.
- Blocked negative configurations by asserting that the raw integer reading from `json_object_get_int64()` fits cleanly within the bounds of a standard unsigned integer `[0, UINT_MAX]`.
- Throws an explicit parsing exception containing the faulty key/value context instead of allowing silent corruption or type wraparounds to leak into properties downstream.

## How I Found It
While validating edge-case scenarios for remote target options within the backup configuration layout, I tested unexpected values inside an `ssh-push` block. Providing a negative integer or an overflowing data block did not trip the parser; instead, it triggered downstream system faults inside the connection subsystem because the network layer received a completely mangled wrapped integer value instead of the expected port structure.