### PR TITLE
Add a manpage for snapper-sync

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -242,6 +242,7 @@ AC_CONFIG_FILES([
 	doc/snapperd.xml:doc/snapperd.xml.in
 	doc/snapper-configs.xml:doc/snapper-configs.xml.in
 	doc/snbk.xml:doc/snbk.xml.in
+	doc/snapper-sync.xml:doc/snapper-sync.xml.in
 	doc/snapper-backup-configs.xml:doc/snapper-backup-configs.xml.in
 	doc/snapper-zypp-plugin.xml:doc/snapper-zypp-plugin.xml.in
 	doc/snapper-zypp-plugin.conf.xml:doc/snapper-zypp-plugin.conf.xml.in

--- a/dists/debian/snapper-backup.manpages
+++ b/dists/debian/snapper-backup.manpages
@@ -1,2 +1,3 @@
 debian/tmp/usr/share/man/man8/snbk.8
+debian/tmp/usr/share/man/man8/snapper-sync.8
 debian/tmp/usr/share/man/man5/snapper-backup-configs.5

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -4,7 +4,8 @@
 
 if ENABLE_DOC
 
-man_MANS = snapper.8 snapperd.8 snapper-configs.5 snbk.8 snapper-backup-configs.5
+man_MANS = snapper.8 snapperd.8 snapper-configs.5		\
+	   snbk.8 snapper-sync.8 snapper-backup-configs.5
 
 if HAVE_PAM
 man_MANS += pam_snapper.8

--- a/doc/snapper-sync.xml.in
+++ b/doc/snapper-sync.xml.in
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry id='snapper-sync8' xmlns:xlink="http://www.w3.org/1999/xlink">
+
+  <refentryinfo>
+    <date>2026-07-16</date>
+  </refentryinfo>
+
+  <refmeta>
+    <refentrytitle>snapper-sync</refentrytitle>
+    <manvolnum>8</manvolnum>
+    <refmiscinfo class='date'>2026-07-16</refmiscinfo>
+    <refmiscinfo class='version'>@VERSION@</refmiscinfo>
+    <refmiscinfo class='manual'>Filesystem Snapshot Management</refmiscinfo>
+  </refmeta>
+
+  <refnamediv>
+    <refname>snapper-sync</refname>
+    <refpurpose>Script to synchronize the highest snapshot number</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv id='synopsis'>
+    <cmdsynopsis>
+      <command>snapper-sync</command>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+
+  <refsect1 id='description'>
+    <title>DESCRIPTION</title>
+    <para><command>snapper-sync</command> is a script to synchronize the highest snapshot
+    number across the source and backup target devices, avoiding a potential snapshot
+    number collision after restoration. For details, please refer to the
+    <citerefentry>
+      <refentrytitle>snbk</refentrytitle><manvolnum>8</manvolnum>
+    </citerefentry>
+    documentation</para>
+  </refsect1>
+
+  <refsect1 id='exit_status'>
+    <title>EXIT STATUS</title>
+    <para>Normally the exit status is 0. If an error occurred the exit status is 1.</para>
+  </refsect1>
+
+  <refsect1 id='homepage'>
+    <title>HOMEPAGE</title>
+    <para><ulink url='http://snapper.io/'>http://snapper.io/</ulink></para>
+  </refsect1>
+
+  <refsect1 id='authors'>
+    <title>AUTHORS</title>
+    <para>Arvin Schnell <email>aschnell@suse.com</email></para>
+  </refsect1>
+
+  <refsect1 id='see_also'>
+    <title>SEE ALSO</title>
+    <para>
+      <citerefentry><refentrytitle>snbk</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+    </para>
+  </refsect1>
+
+</refentry>

--- a/snapper.spec.in
+++ b/snapper.spec.in
@@ -380,6 +380,7 @@ A backup program for snapshots created by snapper.
 %{_unitdir}/snapper-timeline.timer.d
 %{_unitdir}/snapper-timeline.timer.d/10-snapper-sync-override.conf
 %{_mandir}/*/snbk.8*
+%{_mandir}/*/snapper-sync.8*
 %{_mandir}/*/snapper-backup-configs.5*
 %dir %{_datadir}/bash-completion
 %dir %{_datadir}/bash-completion/completions


### PR DESCRIPTION
This pull request adds a manpage for the `snapper-sync` script.
The `snapper-sync` manpage includes a short description of the use case and redirects users to read the `snbk` documentation for details.

resolve #1134 