### PR TITLE
fix: handle CRLF line endings in AsciiFile parser

### DIFF
--- a/snapper/AsciiFile.cc
+++ b/snapper/AsciiFile.cc
@@ -172,6 +172,9 @@ namespace snapper
 	if (n > 0 && buffer[n - 1] == '\n')
 	    n--;
 
+	if (n > 0 && buffer[n - 1] == '\r')
+	    n--;
+
 	line = string(buffer, 0, n);
 
 	return true;
@@ -348,6 +351,8 @@ namespace snapper
 	    if (p2)
 	    {
 		line += string(p1, p2 - p1);
+		if (!line.empty() && line.back() == '\r')
+		    line.pop_back();
 		buffer_read = p2 - buffer.data() + 1;
 		return true;
 	    }

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -6,7 +6,7 @@ AM_CPPFLAGS = -I$(top_srcdir) $(DBUS_CFLAGS)
 
 LDADD = ../snapper/libsnapper.la ../dbus/libdbus.la -lboost_unit_test_framework
 
-check_PROGRAMS = sysconfig-get1.test dirname1.test basename1.test 		\
+check_PROGRAMS = sysconfig-get1.test sysconfig-crlf.test dirname1.test basename1.test 		\
 	equal-date.test cmp-lt.test humanstring.test uuid.test			\
 	table.test table-formatter.test csv-formatter.test json-formatter.test	\
 	getopts.test scan-datetime.test root-prefix.test range.test limit.test
@@ -23,7 +23,7 @@ TESTS = $(check_PROGRAMS)
 
 AM_DEFAULT_SOURCE_EXT = .cc
 
-EXTRA_DIST = $(noinst_SCRIPTS) sysconfig-get1.txt sysconfig-set1.txt
+EXTRA_DIST = $(noinst_SCRIPTS) sysconfig-get1.txt sysconfig-set1.txt sysconfig-crlf.txt
 
 equal_date_test_LDADD = -lboost_unit_test_framework ../client/utils/libutils.la
 

--- a/testsuite/sysconfig-crlf.cc
+++ b/testsuite/sysconfig-crlf.cc
@@ -1,0 +1,19 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE sysconfig_crlf
+
+#include <boost/test/unit_test.hpp>
+
+#include <snapper/AsciiFile.h>
+
+using namespace snapper;
+
+
+BOOST_AUTO_TEST_CASE(sysconfig_crlf)
+{
+    SysconfigFile s("sysconfig-crlf.txt");
+
+    string value;
+    BOOST_REQUIRE(s.get_value("KEY", value));
+    BOOST_CHECK_EQUAL(value, "value");
+}

--- a/testsuite/sysconfig-crlf.txt
+++ b/testsuite/sysconfig-crlf.txt
@@ -1,0 +1,1 @@
+KEY="value"


### PR DESCRIPTION
## Summary

Strip trailing carriage returns (`\r`) when reading ASCII and gzip files.

This fixes parsing of Windows-style CRLF configuration files, where values previously retained a trailing `\r` and were parsed incorrectly.

## Changes

- Strip trailing `\r` before processing each line.
- Add a regression test covering CRLF sysconfig input.

## Testing

- Added new `sysconfig-crlf.test`.
- Existing tests continue to pass.