### PR TITLE
Remove auto-generated sysconfig-crlf.txt from the testsuite Makefile

### DIFF
--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -23,7 +23,7 @@ TESTS = $(check_PROGRAMS)
 
 AM_DEFAULT_SOURCE_EXT = .cc
 
-EXTRA_DIST = $(noinst_SCRIPTS) sysconfig-get1.txt sysconfig-set1.txt sysconfig-crlf.txt
+EXTRA_DIST = $(noinst_SCRIPTS) sysconfig-get1.txt sysconfig-set1.txt
 
 equal_date_test_LDADD = -lboost_unit_test_framework ../client/utils/libutils.la
 


### PR DESCRIPTION
This PR removes the auto-generated `sysconfig-crlf.txt` file from `testsuite/Makefile.am` to prevent `make package` from depending on `make check`.

The `sysconfig-crlf.txt` is auto-generated by `testsuite/sysconfig-crlf.cc`, so I assume it does not need to be included in the Makefile.