### PR TITLE
Add retention config for snbk

### DIFF
--- a/client/snbk/BackupConfig.cc
+++ b/client/snbk/BackupConfig.cc
@@ -37,6 +37,9 @@ namespace snapper
 
     const vector<string> EnumInfo<BackupConfig::TargetMode>::names({ "local", "ssh-push" });
 
+    const vector<string> EnumInfo<BackupConfig::RetentionPolicy>::names({ "default",
+                                                                          "custom" });
+
 
     BackupConfig::BackupConfig(const string& name)
 	: name(name)
@@ -77,6 +80,18 @@ namespace snapper
 	get_child_value(json_file.get_root(), "target-mkdir-bin", target_mkdir_bin);
 	get_child_value(json_file.get_root(), "target-rm-bin", target_rm_bin);
 	get_child_value(json_file.get_root(), "target-rmdir-bin", target_rmdir_bin);
+
+	if (get_child_value(json_file.get_root(), "retention-policy", tmp1))
+	{
+	    if (!toValue(tmp1, retention_policy, false))
+		SN_THROW(Exception(sformat("unknown retention-policy '%s' in '%s'",
+		                           tmp1.c_str(), name.c_str())));
+	    if (retention_policy == RetentionPolicy::CUSTOM &&
+	        !get_child_value(json_file.get_root(), "retention-config",
+	                         retention_config))
+		SN_THROW(Exception(
+		    sformat("retention-config entry not found in '%s'", name.c_str())));
+	}
     }
 
 

--- a/client/snbk/BackupConfig.h
+++ b/client/snbk/BackupConfig.h
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -36,6 +37,7 @@
 namespace snapper
 {
 
+    using std::map;
     using std::string;
     using std::vector;
 
@@ -47,6 +49,25 @@ namespace snapper
 	enum class TargetMode
 	{
 	    LOCAL, SSH_PUSH
+	};
+
+	enum class RetentionPolicy
+	{
+	    /**
+	     * The default policy means keeping the snapshots on the backup device
+	     * identical to the source device. If the retention policy (`retention-policy`
+	     * in the config) is set to `default`, the retention config
+	     * (`retention-config` in the config) is ignored.
+	     */
+	    DEFAULT,
+
+	    /**
+	     * The custom policy means the snapshot retention can be different from the
+	     * source device. The behavior can be controlled via `retention-config` in the
+	     * config. The parameters share the same names as `snapper` options (e.g.,
+	     * NUMBER_LIMIT, TIMELINE_LIMIT_HOURLY, ...).
+	     */
+	    CUSTOM
 	};
 
 	BackupConfig(const string& name);
@@ -81,6 +102,9 @@ namespace snapper
 	string target_rm_bin = RM_BIN;
 	string target_rmdir_bin = RMDIR_BIN;
 
+	RetentionPolicy retention_policy = RetentionPolicy::DEFAULT;
+	map<string, string> retention_config;
+
     private:
 
 	vector<string> ssh_options() const;
@@ -92,6 +116,11 @@ namespace snapper
 
 
     template <> struct EnumInfo<BackupConfig::TargetMode> { static const vector<string> names; };
+
+    template <> struct EnumInfo<BackupConfig::RetentionPolicy>
+    {
+	static const vector<string> names;
+    };
 
 
     vector<string>

--- a/client/snbk/JsonFile.cc
+++ b/client/snbk/JsonFile.cc
@@ -194,6 +194,32 @@ namespace snapper
     }
 
 
+    template <>
+    bool
+    get_child_value(json_object* parent, const char* name, map<string, string>& value)
+    {
+	json_object* child;
+
+	if (!json_object_object_get_ex(parent, name, &child))
+	    return false;
+	if (!json_object_is_type(child, json_type_object))
+	    return false;
+
+	map<string, string> result;
+	json_object_object_foreach(child, key, val)
+	{
+	    if (!json_object_is_type(val, json_type_string))
+		return false;
+
+	    result[key] = json_object_get_string(val);
+	}
+
+	value = result;
+
+	return true;
+    }
+
+
     bool
     get_child_nodes(json_object* parent, const char* name, vector<string>& values)
     {


### PR DESCRIPTION
This PR adds `retention-policy` and `retention-config` entries to the snbk `BackupConfig`.  
The `retention-policy` supports `default` and `custom` options. The `default` policy is designed to keep the snapshots on the backup device identical to those on the source device (the existing behavior); the `custom` policy requires an additional configuration entry `retention-config`, which defines the cleanup behavior.

The parameters under the `retention-config` section share the same names as `snapper` configuration options (NUMBER_LIMIT, TIMELINE_LIMIT_HOURLY, ...), so that the cleanup parameter class (the `Parameters` class in `client/cleanup.cc`) can load the config without a major interface modification.

An example config:

```json
{
  "config": "test",
  "target-mode": "local",
  "target-path": "/mnt/test-btrfs-target/.snapper/data",
  "automatic": false,
  "retention-policy": "custom",
  "retention-config": {
    "NUMBER_MIN_AGE": "3600",
    "NUMBER_LIMIT": "50",
    "NUMBER_LIMIT_IMPORTANT": "10",
    "TIMELINE_MIN_AGE": "3600",
    "TIMELINE_LIMIT_HOURLY": "48",
    "TIMELINE_LIMIT_DAILY": "14",
    "TIMELINE_LIMIT_WEEKLY": "12",
  }
}
```

Additional changes:

- A specialized `get_child_value` function is added to the `JsonFile` module to support parsing a JSON node into a string-to-string dictionary.

Things to discuss:

- The style of cleanup parameters (NUMBER_LIMIT, TIMELINE_LIMIT_HOURLY, ...) does not match the existing snbk configuration style (target-mode, target-path, ...). It's fine with me, but I'm not sure what others think.

Parent issue: #1105